### PR TITLE
use nullhandler for logging rather than logging to file.

### DIFF
--- a/geowombat/backends/rasterio_.py
+++ b/geowombat/backends/rasterio_.py
@@ -4,8 +4,6 @@ from pathlib import Path
 from collections import namedtuple
 import threading
 
-from ..errors import logger
-
 import numpy as np
 import rasterio as rio
 from rasterio.crs import CRS
@@ -18,6 +16,10 @@ from rasterio.coords import BoundingBox
 
 import pyproj
 from affine import Affine
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 try:
     import zarr

--- a/geowombat/backends/xarray_.py
+++ b/geowombat/backends/xarray_.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from ..core.windows import get_window_offsets
 from ..core.util import parse_filename_dates
-from ..errors import logger
 from ..config import config
 from .rasterio_ import get_ref_image_meta, warp, warp_images, get_file_bounds, window_to_bounds, unpack_bounding_box, unpack_window
 from .rasterio_ import transform_crs as rio_transform_crs
@@ -18,6 +17,8 @@ from xarray.ufuncs import maximum as xr_maximum
 from xarray.ufuncs import minimum as xr_mininum
 from deprecated import deprecated
 
+import logging
+logger = logging.getLogger(__name__)
 
 def _update_kwarg(ref_obj, ref_kwargs, key):
 
@@ -599,7 +600,7 @@ def concat(filenames,
                     src.attrs['sensor'] = src.gw.sensor_names[src.gw.sensor]
 
     if dtype:
-        
+
         attrs = src.attrs.copy()
         return src.astype(dtype).assign_attrs(**attrs)
 

--- a/geowombat/core/api.py
+++ b/geowombat/core/api.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from . import geoxarray
 from ..config import config, _set_defaults
-from ..errors import logger
 from ..backends import concat as gw_concat
 from ..backends import mosaic as gw_mosaic
 from ..backends import warp_open
@@ -21,7 +20,8 @@ from rasterio.windows import from_bounds, Window
 import dask
 import dask.array as da
 
-
+import logging
+logger = logging.getLogger(__name__)
 warnings.filterwarnings('ignore')
 
 ch = Chunks()
@@ -339,7 +339,6 @@ class open(object):
                  dtype=None,
                  num_workers=1,
                  **kwargs):
-
         if isinstance(filename, Path):
             filename = str(filename)
 

--- a/geowombat/core/base.py
+++ b/geowombat/core/base.py
@@ -1,5 +1,5 @@
-from ..errors import logger
-
+import logging
+logger = logging.getLogger(__name__)
 
 class PropertyMixin(object):
 

--- a/geowombat/core/conversion.py
+++ b/geowombat/core/conversion.py
@@ -1,7 +1,6 @@
 import os
 import multiprocessing as multi
 
-from ..errors import logger
 from ..backends.rasterio_ import check_crs
 from .util import sample_feature
 from .util import lazy_wombat
@@ -20,6 +19,9 @@ from affine import Affine
 import pyproj
 from tqdm import tqdm
 from deprecated import deprecated
+
+import logging
+logger = logging.getLogger(__name__)
 
 shapely.speedups.enable()
 
@@ -357,8 +359,8 @@ class Converters(object):
 
         if not id_column in df.columns:
             df[id_column] = df.index.values
-        
-                
+
+
         df_crs = check_crs(df.crs).to_proj4()
         data_crs = check_crs(data.crs).to_proj4()
 

--- a/geowombat/core/io.py
+++ b/geowombat/core/io.py
@@ -10,7 +10,6 @@ import threading
 import random
 import string
 
-from ..errors import logger
 from ..backends.rasterio_ import to_gtiff, WriteDaskArray
 from .windows import get_window_offsets
 
@@ -43,6 +42,10 @@ try:
 except:
     MKL_LIB = None
 
+import logging
+logger = logging.getLogger(__name__)
+
+logger.debug("importing io module")
 
 def get_norm_indices(n_bands, window_slice, indexes_multi):
 
@@ -788,7 +791,7 @@ def to_raster(data,
 
                     for __ in tqdm(map(_write_xarray, data_gen), total=n_windows_slice):
                         pass
-                    
+
                 else:
 
                     with pool_executor(n_workers) as executor:

--- a/geowombat/core/io.py
+++ b/geowombat/core/io.py
@@ -45,7 +45,6 @@ except:
 import logging
 logger = logging.getLogger(__name__)
 
-logger.debug("importing io module")
 
 def get_norm_indices(n_bands, window_slice, indexes_multi):
 

--- a/geowombat/core/sops.py
+++ b/geowombat/core/sops.py
@@ -4,7 +4,6 @@ import itertools
 from datetime import datetime
 from collections import defaultdict
 
-from ..errors import logger
 from ..backends.rasterio_ import align_bounds, array_bounds, aligned_target
 from .conversion import Converters
 from .base import PropertyMixin as _PropertyMixin
@@ -35,6 +34,8 @@ try:
 except:
     PYMORPH_INSTALLED = False
 
+import logging
+logger = logging.getLogger(__name__)
 
 def _remove_near_points(dataframe, r):
 

--- a/geowombat/core/util.py
+++ b/geowombat/core/util.py
@@ -4,7 +4,6 @@ from collections import namedtuple, OrderedDict
 from datetime import datetime
 from pathlib import Path
 
-from ..errors import logger
 from ..moving import moving_window
 
 import numpy as np
@@ -25,6 +24,10 @@ try:
     DATEPARSER_INSTALLED = True
 except:
     DATEPARSER_INSTALLED = False
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 speedups.enable()
 
@@ -459,7 +462,7 @@ def sample_feature(fid, geom, crs, res, all_touched, meta, frac, feature_array=N
         return gpd.GeoDataFrame([])
 
     if not isinstance(feature_array, np.ndarray):
-    
+
         # "Rasterize" the geometry into a NumPy array
         feature_array = features.rasterize([geom],
                                            out_shape=geom_info.shape,

--- a/geowombat/core/vi.py
+++ b/geowombat/core/vi.py
@@ -1,9 +1,11 @@
-from ..errors import logger
 from .base import PropertyMixin as _PropertyMixin
 
 import numpy as np
 import xarray as xr
 import dask.array as da
+
+import logging
+logger = logging.getLogger(__name__)
 
 
 def _create_nodata_array(data, nodata, band_name, var_name):

--- a/geowombat/errors.py
+++ b/geowombat/errors.py
@@ -1,23 +1,9 @@
-import os
 import logging
-
 
 _FORMAT = '%(asctime)s:%(levelname)s:%(lineno)s:%(module)s.%(funcName)s:%(message)s'
 _formatter = logging.Formatter(_FORMAT, '%H:%M:%S')
-_handler = logging.StreamHandler()
+_handler = logging.NullHandler()
 _handler.setFormatter(_formatter)
-
-_log_home = os.path.abspath(os.path.dirname(__file__))
-
-if not os.access(_log_home, os.W_OK):
-    _log_home = os.path.expanduser('~')
-
-_log_file = os.path.join(_log_home, 'geowombat.log')
-
-logging.basicConfig(filename=_log_file,
-                    filemode='w',
-                    level=logging.DEBUG)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(_handler)
-logger.setLevel(logging.INFO)

--- a/geowombat/radiometry/angles.py
+++ b/geowombat/radiometry/angles.py
@@ -5,7 +5,6 @@ import subprocess
 from collections import namedtuple
 import tarfile
 
-from ..errors import logger
 
 import numpy as np
 import xarray as xr
@@ -14,6 +13,10 @@ from rasterio.warp import reproject
 from affine import Affine
 import xml.etree.ElementTree as ET
 # from pysolar.solar import get_altitude_fast, get_azimuth_fast
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 try:
     import cv2

--- a/geowombat/radiometry/brdf.py
+++ b/geowombat/radiometry/brdf.py
@@ -3,12 +3,14 @@ from collections import namedtuple
 
 from .angles import relative_azimuth
 from ..core.util import project_coords
-from ..errors import logger
 
 import numpy as np
 import xarray as xr
 import dask
 import dask.array as da
+
+import logging
+logger = logging.getLogger(__name__)
 
 
 def dtor(x):

--- a/geowombat/radiometry/topo.py
+++ b/geowombat/radiometry/topo.py
@@ -1,11 +1,13 @@
-from ..errors import logger
-
 import numpy as np
 from osgeo import gdal, gdal_array
 import dask
 import dask.array as da
 import xarray as xr
 from sklearn.linear_model import LinearRegression, TheilSenRegressor
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 try:
     import cv2

--- a/geowombat/util/plotting.py
+++ b/geowombat/util/plotting.py
@@ -1,9 +1,8 @@
-from ..errors import logger
-
 import xarray as xr
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-
+import logging
+logger = logging.getLogger(__name__)
 
 class Plotting(object):
 

--- a/geowombat/util/web.py
+++ b/geowombat/util/web.py
@@ -10,7 +10,6 @@ import random
 import string
 import time
 
-from ..errors import logger
 from ..radiometry import BRDF, LinearAdjustments, RadTransforms, landsat_pixel_angles, sentinel_pixel_angles, QAMasker
 from ..radiometry.angles import estimate_cloud_shadows
 from ..core import ndarray_to_xarray
@@ -26,6 +25,10 @@ import xarray as xr
 import shapely
 from shapely.geometry import Polygon
 import psutil
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 try:
     import requests
@@ -946,7 +949,7 @@ class GeoDownloads(object):
                                             sr_brdf.gw.to_raster(str(out_brdf), **kwargs)
 
                                         if write_angle_files:
-                                            
+
                                             angle_stack = xr.concat((sza, saa), dim='band').astype('int16')
                                             angle_stack.attrs = sza.attrs.copy()
                                             angle_stack.gw.to_raster(str(out_angles), **angle_kwargs)


### PR DESCRIPTION
It is more convenient for me if the user sets the logging details. When running in a container, for example, you can't always guarantee that the location for the log file will be writeable. It is more flexible if the user is given control of the logging process.

 So, like in [the logging howto](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library) I propose we set the nullhandler in `errors.py`,
then in each module use

```
import logging
logger = logging.getLogger(__name__)
```

The user can then manage how they want to handle the logging themselves. Most of the log gets taken up with rasterio stuff so it's sort of nice to be able to separate that if you wanted anyway.

The `errors.py` module in this approach doesn't actually do much, so might want to consider if it is needed.



