### PR TITLE
old _filenames attribute reference

### DIFF
--- a/geowombat/core/geoxarray.py
+++ b/geowombat/core/geoxarray.py
@@ -247,7 +247,7 @@ class GeoWombatAccessor(_UpdateConfig, _DataProperties):
     @property
     def filenames(self):
         """Get the data filenames"""
-        return self._filenames if hasattr(self, '_filenames') else []
+        return self.filename if hasattr(self, 'filename') else []
 
     @filenames.setter
     def filenames(self, file_list):


### PR DESCRIPTION
Was trying to run to_vrt when I noticed this _filenames call. I am 99% its old