### PR TITLE
reorient docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Like a wombat, GeoWombat has a simple interface (for raster I/O) with a strong b
 * Simple read/write for a variety of sensors, including:
     * Sentinel 2
     * Landsat 5-8
-    * Planetscope
+    * PlanetScope
     * Others 
-* Mosaicing tiles
-* Reproject
-* Extract to points / polygon
+* Image mosaicing
+* On-the-fly image transformations (reprojection)
+* Point / polygon raster sampling, extraction
 * Time series analysis
 * Band math (NDVI, Tasseled cap, EVI etc)
-* Classification with sklearn
+* Image classification and regression
 * Radiometry (BRDF normalization)
 * Distributed processing 
     

--- a/README.md
+++ b/README.md
@@ -6,9 +6,24 @@
 
 ### GeoWombat: Utilities for geospatial data
 
-Like a wombat, GeoWombat has a simple interface (for raster I/O) with a strong backend (for data processing at scale).
+Like a wombat, GeoWombat has a simple interface (for raster I/O) with a strong backend (for data processing at scale). 
 
-## Basic usage
+## Common Remote Sensing Uses
+* Simple read/write for a variety of sensors, including:
+    * Sentinel 2
+    * Landsat 5-8
+    * Planetscope
+    * Others 
+* Mosaicing tiles
+* Reproject
+* Extract to points / polygon
+* Time series analysis
+* Band math (NDVI, Tasseled cap, EVI etc)
+* Classification with sklearn
+* Radiometry (BRDF normalization)
+* Distributed processing 
+    
+## Basic usage - Sentinel & Landsat
 
 ```python
 >>> import geowombat as gw

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -25,9 +25,28 @@ GeoWombat: Utilities for geospatial data
         Like a wombat, <b>geowombat</b> has a simple interface (for raster I/O) with a strong backend (for data processing at scale).
     </div>
 
-GeoWombat provides utilities to process geospatial raster data. The package is inspired by, and built on, several key libraries for large-scale data processing, such as `Dask <http://dask.org>`_, `Geopandas <http://geopandas.org>`_, `Pandas <http://pandas.pydata.org>`_, `Rasterio <https://rasterio.readthedocs.io>`_, and `Xarray <http://xarray.pydata.org>`_. GeoWombat interfaces directly with Xarray for raster I/O, which uses Rasterio to open raster files such as satellite images or aerial photos as `Dask arrays <https://docs.dask.org/en/latest/array.html>`_. GeoWombat uses the `Xarray register <http://xarray.pydata.org/en/stable/internals.html>`_ to extend the functionality of `Xarray DataArrays <http://xarray.pydata.org/en/stable/generated/xarray.DataArray.html>`_.
 
-One of the key features of GeoWombat is the on-the-fly handling of multiple files. In particular, GeoWombat leverages Rasterio to transform and align rasters with varying projections and spatial resolutions. In addition to simplifying the process of data alignment, GeoWombat utilizes the `task graphs <https://docs.dask.org/en/latest/graphs.html>`_ of Dask arrays. By default, GeoWombat loads a raster as a DataArray, which points to the raster data on file using a chunked Dask array. This task graph feature simplifies parallel computations of one or more raster files of any size.
+Raster & Remotely Sensed Data Made Easy
+##########
+
+GeoWombat provides utilities to process geospatial and time series of raster data at scale. Easily process Landsat, Sentinel, Planetscope or RGB data and others. 
+
+**Common Remote Sensing Uses**
+* Simple read/write for a variety of sensors (Landsat, Sentinel etc)
+* Mosaicing tiles
+* Reproject
+* Extract to points / polygon
+* Time series analysis
+* Band math (NDVI, Tasseled cap, EVI etc)
+* Classification with sklearn
+* Radiometry (BRDF normalization)
+* Distributed processing 
+
+**Mosaic Images Example**
+.. image:: _static/union_example.png
+   :width: 300
+   :target: _static/union_example.png
+   
 
 .. raw:: html
 
@@ -76,6 +95,12 @@ One of the key features of GeoWombat is the on-the-fly handling of multiple file
                                  compress='lzw')
 
 For more details, see the `tutorials <tutorial.html>`_ and `examples <examples.html>`_.
+
+
+The package is inspired by, and built on, several key libraries for large-scale data processing, such as `Dask <http://dask.org>`_, `Geopandas <http://geopandas.org>`_, `Pandas <http://pandas.pydata.org>`_, `Rasterio <https://rasterio.readthedocs.io>`_, and `Xarray <http://xarray.pydata.org>`_. GeoWombat interfaces directly with Xarray for raster I/O, which uses Rasterio to open raster files such as satellite images or aerial photos as `Dask arrays <https://docs.dask.org/en/latest/array.html>`_. GeoWombat uses the `Xarray register <http://xarray.pydata.org/en/stable/internals.html>`_ to extend the functionality of `Xarray DataArrays <http://xarray.pydata.org/en/stable/generated/xarray.DataArray.html>`_.
+
+One of the key features of GeoWombat is the on-the-fly handling of multiple files. In particular, GeoWombat leverages Rasterio to transform and align rasters with varying projections and spatial resolutions. In addition to simplifying the process of data alignment, GeoWombat utilizes the `task graphs <https://docs.dask.org/en/latest/graphs.html>`_ of Dask arrays. By default, GeoWombat loads a raster as a DataArray, which points to the raster data on file using a chunked Dask array. This task graph feature simplifies parallel computations of one or more raster files of any size.
+
 
 .. toctree::
    :maxdepth: 1

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -33,14 +33,15 @@ GeoWombat provides utilities to process geospatial and time series of raster dat
 
 **Common Remote Sensing Uses**
 * Simple read/write for a variety of sensors (Landsat, Sentinel etc)
-* Mosaicing tiles
-* Reproject
-* Extract to points / polygon
+* Image mosaicing
+* On-the-fly image transformations (reprojection)
+* Point / polygon raster sampling, extraction
 * Time series analysis
 * Band math (NDVI, Tasseled cap, EVI etc)
-* Classification with sklearn
+* Image classification and regression
 * Radiometry (BRDF normalization)
 * Distributed processing 
+
 
 **Mosaic Images Example**
 .. image:: _static/union_example.png


### PR DESCRIPTION
Just reflecting on how to increase the uptake for geowombat.  One issue is the documentation. Here's what I am thinking:

Problem
-  keywords missing
-  keywords not in title or headings
- description too technical and dense with text
- needs more visual examples to draw people in


I just made a few basics edits, feel free to change however you want, but I think it will give a cleaner, approachable description that hopefully will get picked up better by the search bots. 

