### PR TITLE
Update conversion.py

### DIFF
--- a/geowombat/core/conversion.py
+++ b/geowombat/core/conversion.py
@@ -18,6 +18,7 @@ import geopandas as gpd
 from rasterio.features import rasterize, shapes
 from rasterio.warp import aligned_target
 from rasterio.crs import CRS
+from rasterio.dtypes import get_minimum_dtype
 from shapely.geometry import Polygon, MultiPolygon
 from affine import Affine
 import pyproj
@@ -744,6 +745,8 @@ class Converters(object):
 
         if col:
             shapes = ((geom,value) for geom, value in zip(dataframe.geometry, dataframe[col]))
+            dtype = get_minimum_dtype(dataframe[col])
+
         else: 
             shapes = dataframe.geometry.values
             


### PR DESCRIPTION
**Code**
Current in `conversion.py`
``` python 
def polygon_to_array(
        self,
        polygon,
        col=None,
        data=None,
        ...
        dtype="uint16",
        ):
 ....

 if col:
            shapes = (
                (geom, value) for geom, value in zip(dataframe.geometry, dataframe[col])
                )
            
 else:
            shapes = dataframe.geometry.values

 varray = rasterize(
                    shapes,
                    out_shape=(dst_height, dst_width),
                    transform=dst_transform,
                    fill=fill,
                    default_value=default_value,
                    all_touched=all_touched,
                    dtype=dtype,
                )
```

**Problem**
- ml.fit_predict attempted to recast model predictions to unit16. 
- this throws type error in rasterizer when prediction can't be recast


**Solution**
- If 'col' is included, use rasterio.dtypes.get_minimum_dtype to update dtype. 
- The proposed solution is tesed and works for continuous and int dtypes


``` python 
if col:
            shapes = (
                (geom, value) for geom, value in zip(dataframe.geometry, dataframe[col])
            )
            dtype=get_minimum_dtype(dataframe[col])
            
 else:
            shapes = dataframe.geometry.values

 varray = rasterize(
                shapes,
                out_shape=(dst_height, dst_width),
                transform=dst_transform,
                fill=fill,
                default_value=default_value,
                all_touched=all_touched,
                dtype=dtype,
            )
```