### PR TITLE
jgrss/to raster

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     scipy>=1.5.0              # via -r requirements.in, scikit-learn
     shapely>=1.7.0            # via -r requirements.in, geopandas
     tqdm>=4.62.0              # via -r requirements.in
-    xarray>=0.17.0            # via -r requirements.in
+    xarray>=0.17.0,<2022.0.0            # via -r requirements.in
     cryptography
     setuptools>=59.5.0;python_version>='3.8.12'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     scipy>=1.5.0              # via -r requirements.in, scikit-learn
     shapely>=1.7.0            # via -r requirements.in, geopandas
     tqdm>=4.62.0              # via -r requirements.in
-    xarray>=0.17.0,<2022.0.0            # via -r requirements.in
+    xarray>=0.17.0,<=2022.3.0            # via -r requirements.in
     cryptography
     setuptools>=59.5.0;python_version>='3.8.12'
 

--- a/src/geowombat/core/io.py
+++ b/src/geowombat/core/io.py
@@ -708,6 +708,9 @@ def to_raster(
 
     chunksize = (data.gw.row_chunks, data.gw.col_chunks)
 
+    if tqdm_kwargs is None:
+        tqdm_kwargs = {}
+
     # Force tiled outputs with no file sharing
     kwargs['sharing'] = False
 


### PR DESCRIPTION
## What is this PR changing?
This PR fixes a conflict with `xarray>2022.3.0` and `to_raster()`.

* Xarray is capped at `v2022.3.0` following #183.
* `to_raster()` is fixed following issues raised in #184.