### PR TITLE
jgrss/py_version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ packages=find:
 include_package_data = True
 setup_requires =
     cython>=0.29.*
+python_requires = >=3.8
 install_requires =
     dask[array,dataframe]>=2021.*
     distributed>=2021.*


### PR DESCRIPTION
## What is this PR changing?
Pins the minimum Python version to 3.8