### PR TITLE
feat: add the possibility to specify a weight for the volumetric term of the c-factor brdf correction

### DIFF
--- a/src/geowombat/radiometry/brdf.py
+++ b/src/geowombat/radiometry/brdf.py
@@ -394,6 +394,7 @@ class BRDF(GeoVolKernels):
         scale_factor=1.0,
         out_range=None,
         scale_angles=True,
+        vol_weight=1.0
     ):
         r"""Applies Nadir Bidirectional Reflectance Distribution Function (BRDF) normalization
         using the global c-factor method
@@ -413,6 +414,7 @@ class BRDF(GeoVolKernels):
             scale_factor (Optional[float]): A scale factor to apply to the input data.
             out_range (Optional[float]): The out data range. If not given, the output data are return in a 0-1 range.
             scale_angles (Optional[bool]): Whether to scale the pixel angle arrays.
+            vol_weight (Optional[float]): Weight to be applied to the volumetric kernel in the c-factor equation
 
         References:
 
@@ -510,11 +512,11 @@ class BRDF(GeoVolKernels):
             # c-factor
             c_factor = (
                 coeffs['fiso']
-                + coeffs['fvol'] * self.vol_norm
+                + coeffs['fvol'] * self.vol_norm * vol_weight
                 + coeffs['fgeo'] * self.geo_norm
             ) / (
                 coeffs['fiso']
-                + coeffs['fvol'] * self.vol_sensor
+                + coeffs['fvol'] * self.vol_sensor * vol_weight
                 + coeffs['fgeo'] * self.geo_sensor
             )
 


### PR DESCRIPTION
## What is this PR changing?
It introduces a new attribute for norm_brdf() to set a weight for the c-factor brdf correction.

```
def norm_brdf(
        self,
        data,
        solar_za,
        solar_az,
        sensor_za,
        sensor_az,
        central_latitude=None,
        sensor=None,
        wavelengths=None,
        src_nodata=-32768,
        dst_nodata=-32768,
        mask=None,
        scale_factor=1.0,
        out_range=None,
        scale_angles=True,
        vol_weight=1.0
    ):
```
  
### Description
We found that in dense forests, the c-factor correction is under-correcting to the BRDF effect. Adding a weight to the volumetric kernel improves the results. We found a factor of 3.0 to deliver the best result.

Example:
```
sr_brdf = brdf.norm_brdf(data,
                                                  solar_za,
                                                  solar_az,
                                                  sensor_za,
                                                  sensor_az,
                                                   sensor='l8',
                                                   wavelengths=data.band.values.tolist(),
                                                   src_nodata=nodataval,
                                                   dst_nodata=np.nan,
                                                   vol_weight=3.0)
```
