### PR TITLE
jgrss/setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages=find:
 include_package_data = True
 setup_requires =
     cython>=0.29.0
-python_requires = >=3.8
+python_requires = >=3.7
 install_requires =
     dask[array,dataframe]>=2022.1.1,<=2022.8.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
     distributed>=2022.1.1,<=2022.8.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ package_dir=
 packages=find:
 include_package_data = True
 setup_requires =
-    cython>=0.29.*
+    cython>=0.29.0
 python_requires = >=3.8
 install_requires =
     dask[array,dataframe]>=2022.1.1,<=2022.8.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
@@ -32,7 +32,7 @@ install_requires =
     joblib>=0.16.0
     matplotlib>=3.3.0
     numpy>=1.19.0
-    pandas>=1.*
+    pandas>=1.0.0
     pyproj>=3.0.0,<4.0.0
     rasterio>=1.3.0,<2.0.0
     retry
@@ -45,7 +45,7 @@ install_requires =
     h5netcdf>=1.0.2
     cryptography
     threadpoolctl>=3.1.0
-    setuptools>=59.5.0;python_version>='3.8.12'
+    setuptools>=59.5.0
 
 [options.extras_require]
 docs = numpydoc


### PR DESCRIPTION
## What is this PR changing?
Recent builds are failing because `setuptools` is not parsing `setup.cfg` properly. This PR pins required packages to full versions.