### PR TITLE
jgrss/#240

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     tqdm>=4.62.0
     xarray>=2022.6.0
     h5netcdf>=1.0.2
-    cryptography
+    cryptography>=38.0.0
     threadpoolctl>=3.1.0
     setuptools>=59.5.0
 

--- a/src/geowombat/backends/xarray_.py
+++ b/src/geowombat/backends/xarray_.py
@@ -449,12 +449,12 @@ def mosaic(
                                 (darray.mean(dim='band') != ref_kwargs['nodata'])
                                 & (darrayb.mean(dim='band') == ref_kwargs['nodata']),
                                 darray,
-                                np.mininum(darray, darrayb),
+                                np.minimum(darray, darrayb),
                             ),
                         )
 
                     else:
-                        darray = np.mininum(darray, darrayb)
+                        darray = np.minimum(darray, darrayb)
 
                 elif overlap == 'max':
                     if isinstance(ref_kwargs['nodata'], float) or isinstance(

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -47,9 +47,50 @@ class TestOpen(unittest.TestCase):
         with gw.open(l8_224078_20200518) as src:
             self.assertFalse(src.drop_vars('band').gw.has_band_coord)
 
+    def test_nodata(self):
+        with gw.open(l8_224078_20200518) as src:
+            self.assertEqual(src.gw.nodataval, np.nan)
+        with gw.open(l8_224078_20200518, nodata=0) as src:
+            self.assertEqual(src.gw.nodataval, 0)
+
     def test_open_multiple(self):
         with gw.open([l8_224078_20200518, l8_224078_20200518], stack_dim='time') as src:
             self.assertEqual(src.gw.ntime, 2)
+
+    def test_open_multiple_same(self):
+        with gw.open(
+            [l8_224078_20200518, l8_224078_20200518],
+            time_names=['20200518', '20200518'],
+            stack_dim='time'
+        ) as src:
+            self.assertEqual(src.gw.ntime, 1)
+
+    def test_open_multiple_same_max(self):
+        with gw.open(
+            [l8_224078_20200518, l8_224078_20200518],
+            time_names=['20200518', '20200518'],
+            stack_dim='time',
+            overlap='max'
+        ) as src:
+            self.assertEqual(src.gw.ntime, 1)
+
+    def test_open_multiple_same_min(self):
+        with gw.open(
+            [l8_224078_20200518, l8_224078_20200518],
+            time_names=['20200518', '20200518'],
+            stack_dim='time',
+            overlap='min'
+        ) as src:
+            self.assertEqual(src.gw.ntime, 1)
+
+    def test_open_multiple_same_mean(self):
+        with gw.open(
+            [l8_224078_20200518, l8_224078_20200518],
+            time_names=['20200518', '20200518'],
+            stack_dim='time',
+            overlap='mean'
+        ) as src:
+            self.assertEqual(src.gw.ntime, 1)
 
     def test_has_time_dim(self):
         with gw.open([l8_224078_20200518, l8_224078_20200518], stack_dim='time') as src:

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -2,7 +2,10 @@ import unittest
 from pathlib import Path
 
 import geowombat as gw
-from geowombat.data import l8_224078_20200518, l3b_s2b_00390821jxn0l2a_20210319_20220730_c01
+from geowombat.data import (
+    l8_224078_20200518,
+    l3b_s2b_00390821jxn0l2a_20210319_20220730_c01,
+)
 
 import numpy as np
 import dask
@@ -16,13 +19,13 @@ class TestOpen(unittest.TestCase):
         with gw.open(
             l3b_s2b_00390821jxn0l2a_20210319_20220730_c01,
             chunks={'band': -1, 'y': 256, 'x': 256},
-            engine='h5netcdf'
+            engine='h5netcdf',
         ) as src:
             self.assertEqual(src.shape, (6, 668, 668))
             with xr.open_dataset(
                 l3b_s2b_00390821jxn0l2a_20210319_20220730_c01,
                 chunks={'band': -1, 'y': 256, 'x': 256},
-                engine='h5netcdf'
+                engine='h5netcdf',
             ) as ds:
                 self.assertTrue(np.allclose(src.y.values, ds.y.values))
                 self.assertTrue(np.allclose(src.x.values, ds.x.values))
@@ -49,7 +52,7 @@ class TestOpen(unittest.TestCase):
 
     def test_nodata(self):
         with gw.open(l8_224078_20200518) as src:
-            self.assertEqual(src.gw.nodataval, np.nan)
+            self.assertTrue(np.isnan(src.gw.nodataval))
         with gw.open(l8_224078_20200518, nodata=0) as src:
             self.assertEqual(src.gw.nodataval, 0)
 
@@ -61,7 +64,7 @@ class TestOpen(unittest.TestCase):
         with gw.open(
             [l8_224078_20200518, l8_224078_20200518],
             time_names=['20200518', '20200518'],
-            stack_dim='time'
+            stack_dim='time',
         ) as src:
             self.assertEqual(src.gw.ntime, 1)
 
@@ -70,7 +73,7 @@ class TestOpen(unittest.TestCase):
             [l8_224078_20200518, l8_224078_20200518],
             time_names=['20200518', '20200518'],
             stack_dim='time',
-            overlap='max'
+            overlap='max',
         ) as src:
             self.assertEqual(src.gw.ntime, 1)
 
@@ -79,7 +82,7 @@ class TestOpen(unittest.TestCase):
             [l8_224078_20200518, l8_224078_20200518],
             time_names=['20200518', '20200518'],
             stack_dim='time',
-            overlap='min'
+            overlap='min',
         ) as src:
             self.assertEqual(src.gw.ntime, 1)
 
@@ -88,7 +91,7 @@ class TestOpen(unittest.TestCase):
             [l8_224078_20200518, l8_224078_20200518],
             time_names=['20200518', '20200518'],
             stack_dim='time',
-            overlap='mean'
+            overlap='mean',
         ) as src:
             self.assertEqual(src.gw.ntime, 1)
 
@@ -168,7 +171,7 @@ class TestOpen(unittest.TestCase):
                 dst_crs=4326,
                 dst_width=src.gw.ncols,
                 dst_height=src.gw.nrows,
-                coords_only=True
+                coords_only=True,
             )
             self.assertEqual(test_crs, result.crs)
             self.assertEqual(test_crs, result.gw.crs_to_pyproj)


### PR DESCRIPTION
## What is this PR changing?
Fixes an issue caused by a typo when using `gw.open(..., overlap='min')`. See #240.
