### PR TITLE
jgrss/moving

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8.15
+          python-version: 3.9.16
       - uses: syphar/restore-virtualenv@v1
         id: cache-gwenv
         with:
@@ -67,7 +67,7 @@ jobs:
         run: |
           # Install Python GDAL
           pip install -U pip setuptools>=59.5.0 wheel
-          pip install "cython>=0.29.0,<3.0.0" numpy>=1.19.0
+          pip install numpy>=1.19.0
           GDAL_VERSION=$(gdal-config --version | awk -F'[.]' '{print $1"."$2"."$3}')
           pip install GDAL==$GDAL_VERSION --no-cache-dir
       - name: Install GeoWombat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           pip install GDAL==$GDAL_VERSION --no-cache-dir
       - name: Install GeoWombat
         run: |
+          # Remove compiled Cython files
+          rm -rf src/geowombat/moving/*.so
           pip install arosics --no-deps
           pip install .[ml,coreg,stac,perf,tests]
         if: steps.cache-gwenv.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](data/logo.png)
 
 [![](https://img.shields.io/badge/License-MIT-black.svg)](https://github.com/jgrss/geowombat/blob/main/LICENSE.txt)
-[![python](https://img.shields.io/badge/Python-3.7-3776AB-3.8-3776AB-3.9-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
+[![python](https://img.shields.io/badge/Python-3.7%20%7C%203.8%20%7C%203.9-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
 [![](https://badge.fury.io/gh/jgrss%2Fgeowombat.svg)](https://badge.fury.io/gh/jgrss%2Fgeowombat)
 [![](https://github.com/jgrss/geowombat/actions/workflows/ci.yml/badge.svg)](https://github.com/jgrss/geowombat/actions?query=workflow%3ACI)
 [![](https://img.shields.io/github/repo-size/jgrss/geowombat)](https://shields.io/category/size)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 ![](data/logo.png)
 
 [![](https://img.shields.io/badge/License-MIT-black.svg)](https://github.com/jgrss/geowombat/blob/main/LICENSE.txt)
-[![python](https://img.shields.io/badge/Python-3.7-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
-[![python](https://img.shields.io/badge/Python-3.8-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
-[![python](https://img.shields.io/badge/Python-3.9-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
+[![python](https://img.shields.io/badge/Python-3.7-3776AB-3.8-3776AB-3.9-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
 [![](https://badge.fury.io/gh/jgrss%2Fgeowombat.svg)](https://badge.fury.io/gh/jgrss%2Fgeowombat)
 [![](https://github.com/jgrss/geowombat/actions/workflows/ci.yml/badge.svg)](https://github.com/jgrss/geowombat/actions?query=workflow%3ACI)
 [![](https://img.shields.io/github/repo-size/jgrss/geowombat)](https://shields.io/category/size)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ![](data/logo.png)
 
 [![](https://img.shields.io/badge/License-MIT-black.svg)](https://github.com/jgrss/geowombat/blob/main/LICENSE.txt)
-[![](https://img.shields.io/badge/python-3.7%20%7C%203.8-blue)](https://img.shields.io/badge/python-3.7%20%7C%203.8-blue)
+[![python](https://img.shields.io/badge/Python-3.7-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
+[![python](https://img.shields.io/badge/Python-3.8-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
+[![python](https://img.shields.io/badge/Python-3.9-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
 [![](https://badge.fury.io/gh/jgrss%2Fgeowombat.svg)](https://badge.fury.io/gh/jgrss%2Fgeowombat)
 [![](https://github.com/jgrss/geowombat/actions/workflows/ci.yml/badge.svg)](https://github.com/jgrss/geowombat/actions?query=workflow%3ACI)
 [![](https://img.shields.io/github/repo-size/jgrss/geowombat)](https://shields.io/category/size)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -6,15 +6,15 @@
 
 # -- Path setup --------------------------------------------------------------
 
+from datetime import datetime
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 from pathlib import Path
 
-from datetime import datetime
 import geowombat as gw
-
 
 # -- Project information -----------------------------------------------------
 
@@ -74,6 +74,7 @@ exclude_patterns = ['_build']
 # a list of builtin themes.
 html_theme = 'sphinx_book_theme'
 html_title = ''
+html_extra_path = ['google3b98284c88d0d3f0.html']
 logo_only = True
 html_logo = '_static/logo.png'
 # html_favicon = ''

--- a/doc/source/google3b98284c88d0d3f0.html
+++ b/doc/source/google3b98284c88d0d3f0.html
@@ -1,0 +1,1 @@
+google-site-verification: google3b98284c88d0d3f0.html

--- a/doc/source/gpu.rst
+++ b/doc/source/gpu.rst
@@ -99,13 +99,13 @@ Custom time series modules can be generated with classes following the format be
             """
             Args:
                 array (``numpy.ndarray`` |
-                       ``jax.numpy.DeviceArray`` |
+                       ``jax.Array`` |
                        ``torch.Tensor`` |
                        ``tensorflow.Tensor``): The input array, shaped [time x bands x rows x columns].
 
             Returns:
                 ``numpy.ndarray`` |
-                ``jax.numpy.DeviceArray`` |
+                ``jax.Array`` |
                 ``torch.Tensor`` |
                 ``tensorflow.Tensor``
             """

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: gwenv
 channels:
 - defaults
 dependencies:
-- python=3.8.15
+- python=3.9.16
 - libspatialindex
 - libgdal=3.0.2
 - gdal=3.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages=find:
 include_package_data = True
 setup_requires =
     cython>=0.29.0,<3.0.0
-python_requires = >=3.7
+python_requires = >=3.7,<3.9
 install_requires =
     dask[array,dataframe]>=2022.1.1 # >2022.8.0 breaks some xarray.open_mfdataset tasks
     distributed>=2022.1.1 # >2022.8.0 breaks some xarray.open_mfdataset tasks

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     matplotlib>=3.3.0
     numpy>=1.19.0
     pandas>=1.0.0
-    pyproj>=3.0.0,<=3.4.0  # pyproj==3.5.0 raise error with WKT1_GDAL format, but we do not need Geoarray projection
+    pyproj>=3.0.0,<=3.4.0 # pyproj==3.5.0 raise error with WKT1_GDAL format, but we do not need Geoarray projection
     rasterio>=1.3.0,<2.0.0
     retry
     requests>=2.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ setup_requires =
     cython>=0.29.0,<3.0.0
 python_requires = >=3.7
 install_requires =
-    dask[array,dataframe]>=2022.1.1,<=2022.8.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
-    distributed>=2022.1.1,<=2022.8.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
+    dask[array,dataframe]>=2022.1.1 # >2022.8.0 breaks some xarray.open_mfdataset tasks
+    distributed>=2022.1.1 # >2022.8.0 breaks some xarray.open_mfdataset tasks
     geopandas>=0.8.0
     joblib>=0.16.0
     matplotlib>=3.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 version_variable = src/geowombat/__init__.py:__version__
 branch = main
 upload_to_release = true
-version_source = tag   # Other option is commit
+version_source = tag  # Other option is commit
 GH_TOKEN = GITHUB_TOKEN
 CIRCLECI = false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ setup_requires =
     cython>=0.29.0,<3.0.0
 python_requires = >=3.7,<3.9
 install_requires =
-    dask[array,dataframe]>=2022.1.1 # >2022.8.0 breaks some xarray.open_mfdataset tasks
-    distributed>=2022.1.1 # >2022.8.0 breaks some xarray.open_mfdataset tasks
+    dask[array,dataframe]>=2022.3.2 # >2022.8.0 breaks some xarray.open_mfdataset tasks
+    distributed>=2023.3.2 # >2022.8.0 breaks some xarray.open_mfdataset tasks
     geopandas>=0.8.0
     joblib>=0.16.0
     matplotlib>=3.3.0
@@ -41,7 +41,7 @@ install_requires =
     scipy>=1.5.0
     shapely>=1.7.0
     tqdm>=4.62.0
-    xarray>=2022.6.0
+    xarray>=2023.3.0
     h5netcdf>=1.0.2
     cryptography>=38.0.0
     threadpoolctl>=3.1.0
@@ -87,7 +87,7 @@ ml = dask-ml>=2022.5.27
 perf = rtree
     pygeos
     netCDF4
-    ray
+    ray>=2.3.1
 time = dateparser
 view = ipython
     bokeh

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ setup_requires =
     cython>=0.29.0,<3.0.0
 python_requires = >=3.7,<=3.9.16
 install_requires =
-    dask[array,dataframe]>=2023.1.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
-    distributed>=2023.1.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
+    dask[array,dataframe]>=2023.1.0
+    distributed>=2023.1.0
     geopandas>=0.8.0
     joblib>=0.16.0
     matplotlib>=3.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ setup_requires =
     cython>=0.29.0,<3.0.0
 python_requires = >=3.7,<3.9
 install_requires =
-    dask[array,dataframe]>=2022.3.2 # >2022.8.0 breaks some xarray.open_mfdataset tasks
-    distributed>=2023.3.2 # >2022.8.0 breaks some xarray.open_mfdataset tasks
+    dask[array,dataframe]>=2023.1.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
+    distributed>=2023.1.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
     geopandas>=0.8.0
     joblib>=0.16.0
     matplotlib>=3.3.0
@@ -41,7 +41,7 @@ install_requires =
     scipy>=1.5.0
     shapely>=1.7.0
     tqdm>=4.62.0
-    xarray>=2023.3.0
+    xarray>=2023.1.0
     h5netcdf>=1.0.2
     cryptography>=38.0.0
     threadpoolctl>=3.1.0
@@ -87,7 +87,7 @@ ml = dask-ml>=2022.5.27
 perf = rtree
     pygeos
     netCDF4
-    ray>=2.3.1
+    ray>=2.3.0
 time = dateparser
 view = ipython
     bokeh

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 version_variable = src/geowombat/__init__.py:__version__
 branch = main
 upload_to_release = true
-version_source = tag  # Other option is commit
+version_source = tag # Other option is commit
 GH_TOKEN = GITHUB_TOKEN
 CIRCLECI = false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 version_variable = src/geowombat/__init__.py:__version__
 branch = main
 upload_to_release = true
-version_source = tag # Other option is commit
+version_source = tag  # Other option is commit
 GH_TOKEN = GITHUB_TOKEN
 CIRCLECI = false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific :: Remote Sensing
     Programming Language :: Cython
-    Programming Language :: Python :: 3.7 :: 3.8
+    Programming Language :: Python :: 3.7 :: 3.8 :: 3.9
 
 [options]
 package_dir=
@@ -24,7 +24,7 @@ packages=find:
 include_package_data = True
 setup_requires =
     cython>=0.29.0,<3.0.0
-python_requires = >=3.7,<3.9
+python_requires = >=3.7,<=3.9.16
 install_requires =
     dask[array,dataframe]>=2023.1.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
     distributed>=2023.1.0 # >2022.8.0 breaks some xarray.open_mfdataset tasks
@@ -69,7 +69,7 @@ tests = testfixtures
     docformatter
     isort
 coreg = earthpy
-    pyfftw==0.12.0
+    pyfftw==0.13.1
     bottleneck
     cartopy
     cmocean

--- a/src/geowombat/backends/rasterio_.py
+++ b/src/geowombat/backends/rasterio_.py
@@ -304,7 +304,7 @@ def check_crs(crs: T.Union[CRS, rio.CRS, dict, int, np.number, str]) -> CRS:
     """
     with rio.Env():
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', UserWarning)
+            warnings.simplefilter('ignore', (FutureWarning, UserWarning))
             if isinstance(crs, (CRS, rio.CRS)):
                 dst_crs = CRS.from_wkt(crs.to_wkt())
             elif isinstance(crs, (int, np.number)):

--- a/src/geowombat/core/api.py
+++ b/src/geowombat/core/api.py
@@ -860,6 +860,7 @@ def load(
 class _ImportGPU(object):
 
     try:
+        import jax
         import jax.numpy as jnp
 
         JAX_INSTALLED = True
@@ -961,7 +962,7 @@ class series(BaseSeries):
         self.windows_ = None
 
         if transfer_lib == 'jax':
-            self.out_array_type = imports_.jnp.DeviceArray
+            self.out_array_type = imports_.jax.Array
         elif transfer_lib == 'numpy':
             self.out_array_type = np.ndarray
         elif transfer_lib == 'pytorch':

--- a/src/geowombat/core/geoxarray.py
+++ b/src/geowombat/core/geoxarray.py
@@ -1512,25 +1512,21 @@ class GeoWombatAccessor(_UpdateConfig, _DataProperties):
 
     def moving(
         self,
-        band_coords: str = 'band',
         stat: str = 'mean',
-        perc: int = 50,
-        nodata: T.Union[float, int] = None,
+        perc: T.Union[float, int] = 50,
         w: int = 3,
-        weights: bool = False,
-        n_jobs: int = 1,
+        nodata: T.Optional[T.Union[float, int]] = None,
+        weights: T.Optional[bool] = False,
     ) -> xr.DataArray:
         """Applies a moving window function to the DataArray.
 
         Args:
-            band_coords (Optional[str]): The band coordinate name.
             stat (Optional[str]): The statistic to compute. Choices are
                 ['mean', 'std', 'var', 'min', 'max', 'perc'].
             perc (Optional[int]): The percentile to return if ``stat`` = 'perc'.
-            nodata (Optional[int or float]): A 'no data' value to ignore.
             w (Optional[int]): The moving window size (in pixels).
+            nodata (Optional[int or float]): A 'no data' value to ignore.
             weights (Optional[bool]): Whether to weight values by distance from window center.
-            n_jobs (Optional[int]): The number of rows to process in parallel.
 
         Returns:
             ``xarray.DataArray``
@@ -1540,21 +1536,20 @@ class GeoWombatAccessor(_UpdateConfig, _DataProperties):
             >>>
             >>> # Calculate the mean within a 5x5 window
             >>> with gw.open('image.tif') as src:
-            >>>     res = src.gw.moving(stat='mean', w=5, nodata=32767.0, n_jobs=8)
+            >>>     res = src.gw.moving(stat='mean', w=5, nodata=32767.0)
             >>>
             >>> # Calculate the 90th percentile within a 15x15 window
             >>> with gw.open('image.tif') as src:
-            >>>     res = src.gw.moving(stat='perc', w=15, perc=90, nodata=32767.0, n_jobs=8)
+            >>>     res = src.gw.moving(stat='perc', w=15, perc=90, nodata=32767.0)
+            >>>     res.data.compute(num_workers=4)
         """
         return moving(
             self._obj,
-            band_names=self._obj.coords[band_coords].values,
             perc=perc,
             nodata=nodata,
             w=w,
             stat=stat,
             weights=weights,
-            n_jobs=n_jobs,
         )
 
     def norm_diff(

--- a/src/geowombat/core/io.py
+++ b/src/geowombat/core/io.py
@@ -201,7 +201,7 @@ def _compute_block(
         orows (int): The output image rows.
 
     Returns:
-        ``numpy.ndarray``, ``rasterio.windows.Window``, ``int`` | ``list``
+        ``numpy.ndarray`` | ``rasterio.windows.Window`` | ``int`` | ``list``
     """
     out_data_ = None
     if 'apply' in block.attrs:
@@ -410,7 +410,7 @@ def _write_xarray(*args):
         https://github.com/dask/dask/issues/3600
 
     Returns:
-        ``str`` | None
+        ``str`` | ``None``
     """
     zarr_file = None
     (
@@ -473,6 +473,9 @@ def to_vrt(
         nodata (Optional[float or int]): The 'no data' value for ``rasterio.vrt.WarpedVRT``.
         init_dest_nodata (Optional[bool]): Whether or not to initialize output to ``nodata`` for ``rasterio.vrt.WarpedVRT``.
         warp_mem_limit (Optional[int]): The GDAL memory limit for ``rasterio.vrt.WarpedVRT``.
+
+    Returns:
+        ``None``, writes to ``filename``
 
     Examples:
         >>> import geowombat as gw
@@ -567,6 +570,9 @@ def to_netcdf(
             the ``dask`` task graph. Default is ``True``.
         args (DataArray): Additional ``DataArrays`` to stack.
         kwargs (dict): Encoding arguments.
+
+    Return:
+        ``None``, writes to ``filename``
 
     Examples:
         >>> import geowombat as gw
@@ -876,7 +882,7 @@ def to_raster(
         kwargs (Optional[dict]): Additional keyword arguments to pass to ``rasterio.write``.
 
     Returns:
-        ``dask.delayed`` object
+        ``None``, writes to ``filename``
 
     Examples:
         >>> import geowombat as gw
@@ -1416,7 +1422,7 @@ def apply(
         kwargs (Optional[dict]): Additional keyword arguments to pass to ``rasterio.open``.
 
     Returns:
-        None
+        ``None``, writes to ``outfile``
 
     Examples:
         >>> import geowombat as gw

--- a/src/geowombat/core/io.py
+++ b/src/geowombat/core/io.py
@@ -11,19 +11,6 @@ import typing as T
 import warnings
 from pathlib import Path
 
-from ..backends.rasterio_ import RasterioStore, to_gtiff
-from ..handler import add_handler
-from .windows import get_window_offsets
-
-try:
-    import zarr
-
-    from ..backends.zarr_ import to_zarr
-
-    ZARR_INSTALLED = True
-except ImportError:
-    ZARR_INSTALLED = False
-
 import dask
 import numpy as np
 import pyproj
@@ -41,6 +28,19 @@ from rasterio.windows import Window
 from threadpoolctl import threadpool_limits
 from tqdm import tqdm
 from tqdm.dask import TqdmCallback
+
+try:
+    import zarr
+
+    from ..backends.zarr_ import to_zarr
+
+    ZARR_INSTALLED = True
+except ImportError:
+    ZARR_INSTALLED = False
+
+from ..backends.rasterio_ import RasterioStore, to_gtiff
+from ..handler import add_handler
+from .windows import get_window_offsets
 
 logger = logging.getLogger(__name__)
 logger = add_handler(logger)

--- a/src/geowombat/core/series.py
+++ b/src/geowombat/core/series.py
@@ -315,7 +315,7 @@ class TimeModule(object):
             f"self.count={self.count}\n    "
             f"self.compress='{self.compress}'\n    "
             f"self.bigtiff='{self.bigtiff}'\n    "
-            f"-> Array(numpy.ndarray | jax.numpy.DeviceArray | torch.Tensor | tensorflow.Tensor)[bands x height x width]"
+            f"-> Array(numpy.ndarray | jax.Array | torch.Tensor | tensorflow.Tensor)[bands x height x width]"
         )
 
     def __add__(self, other):
@@ -330,13 +330,13 @@ class TimeModule(object):
 
         Args:
             data (``numpy.ndarray`` |
-                  ``jax.numpy.DeviceArray`` |
+                  ``jax.Array`` |
                   ``torch.Tensor`` |
                   ``tensorflow.Tensor``): The input array, shaped [time x bands x rows x columns].
 
         Returns:
             ``numpy.ndarray`` |
-            ``jax.numpy.DeviceArray`` |
+            ``jax.Array`` |
             ``torch.Tensor`` |
             ``tensorflow.Tensor``:
                 Shaped (time|bands x rows x columns)

--- a/src/geowombat/core/util.py
+++ b/src/geowombat/core/util.py
@@ -15,6 +15,7 @@ from rasterio import features
 from rasterio.crs import CRS
 from rasterio.transform import from_bounds
 from rasterio.warp import reproject, transform_bounds
+from threadpoolctl import threadpool_limits
 
 from ..handler import add_handler
 from ..moving import moving_window
@@ -419,6 +420,7 @@ class MapProcesses(object):
         attrs = data.attrs
         hw = int(w * 0.5)
 
+        @threadpool_limits.wrap(limits=1, user_api='blas')
         def _move_func(block_data: np.ndarray) -> np.ndarray:
             """
             Args:

--- a/src/geowombat/core/util.py
+++ b/src/geowombat/core/util.py
@@ -458,11 +458,11 @@ class MapProcesses(object):
         )
 
         new_attrs = {
-            "moving_stat": stat,
-            "moving_window_size": w,
+            'moving_stat': stat,
+            'moving_window_size': w,
         }
         if stat == 'perc':
-            new_attrs["moving_perc"] = perc
+            new_attrs['moving_perc'] = perc
 
         return results.assign_attrs(**new_attrs)
 

--- a/src/geowombat/moving/_moving.pyx
+++ b/src/geowombat/moving/_moving.pyx
@@ -6,17 +6,13 @@
 # cython: nonecheck=False
 
 import cython
-
 cimport cython
-
 import numpy as np
-
 cimport numpy as np
 
 np._import_array
 
 from ..util cimport percentiles
-
 from cython.parallel import parallel, prange
 
 
@@ -52,13 +48,15 @@ cdef inline double _edist(double xloc, double yloc, double hw) nogil:
     return sqrt(_pow2(xloc - hw) + _pow2(yloc - hw))
 
 
-cdef double _get_var(double[:, ::1] input_view,
-                     Py_ssize_t i,
-                     Py_ssize_t j,
-                     int w,
-                     double w_samples,
-                     double nodata,
-                     double[:, ::1] window_weights) nogil:
+cdef double _get_var(
+    double[:, ::1] input_view,
+    Py_ssize_t i,
+    Py_ssize_t j,
+    int w,
+    double w_samples,
+    double nodata,
+    double[:, ::1] window_weights
+) nogil:
 
     cdef:
         Py_ssize_t m, n
@@ -115,13 +113,15 @@ cdef double _get_var(double[:, ::1] input_view,
             return res
 
 
-cdef double _get_std(double[:, ::1] input_view,
-                     Py_ssize_t i,
-                     Py_ssize_t j,
-                     int w,
-                     double w_samples,
-                     double nodata,
-                     double[:, ::1] window_weights) nogil:
+cdef double _get_std(
+    double[:, ::1] input_view,
+    Py_ssize_t i,
+    Py_ssize_t j,
+    int w,
+    double w_samples,
+    double nodata,
+    double[:, ::1] window_weights
+) nogil:
 
     cdef:
         Py_ssize_t m, n
@@ -180,13 +180,15 @@ cdef double _get_std(double[:, ::1] input_view,
             return res
 
 
-cdef double _get_mean(double[:, ::1] input_view,
-                      Py_ssize_t i,
-                      Py_ssize_t j,
-                      int w,
-                      double w_samples,
-                      double nodata,
-                      double[:, ::1] window_weights) nogil:
+cdef double _get_mean(
+    double[:, ::1] input_view,
+    Py_ssize_t i,
+    Py_ssize_t j,
+    int w,
+    double w_samples,
+    double nodata,
+    double[:, ::1] window_weights
+) nogil:
 
     cdef:
         Py_ssize_t m, n
@@ -225,13 +227,15 @@ cdef double _get_mean(double[:, ::1] input_view,
             return res
 
 
-cdef double _get_expand(double[:, ::1] input_view,
-                        Py_ssize_t i,
-                        Py_ssize_t j,
-                        int w,
-                        double w_samples,
-                        double nodata,
-                        double[:, ::1] window_weights) nogil:
+cdef double _get_expand(
+    double[:, ::1] input_view,
+    Py_ssize_t i,
+    Py_ssize_t j,
+    int w,
+    double w_samples,
+    double nodata,
+    double[:, ::1] window_weights
+) nogil:
 
     cdef:
         Py_ssize_t m, n
@@ -249,13 +253,15 @@ cdef double _get_expand(double[:, ::1] input_view,
     return input_view[i+hw, j+hw]
 
 
-cdef double _get_min(double[:, ::1] input_view,
-                     Py_ssize_t i,
-                     Py_ssize_t j,
-                     int w,
-                     double w_samples,
-                     double nodata,
-                     double[:, ::1] window_weights) nogil:
+cdef double _get_min(
+    double[:, ::1] input_view,
+    Py_ssize_t i,
+    Py_ssize_t j,
+    int w,
+    double w_samples,
+    double nodata,
+    double[:, ::1] window_weights
+) nogil:
 
     cdef:
         Py_ssize_t m, n
@@ -286,19 +292,21 @@ cdef double _get_min(double[:, ::1] input_view,
         return window_min
     else:
 
-        if npy_isnan(window_min):
+        if npy_isnan(window_min) or (window_min == 1e9):
             return nodata
         else:
             return window_min
 
 
-cdef double _get_max(double[:, ::1] input_view,
-                     Py_ssize_t i,
-                     Py_ssize_t j,
-                     int w,
-                     double w_samples,
-                     double nodata,
-                     double[:, ::1] window_weights) nogil:
+cdef double _get_max(
+    double[:, ::1] input_view,
+    Py_ssize_t i,
+    Py_ssize_t j,
+    int w,
+    double w_samples,
+    double nodata,
+    double[:, ::1] window_weights
+) nogil:
 
     cdef:
         Py_ssize_t m, n
@@ -325,7 +333,7 @@ cdef double _get_max(double[:, ::1] input_view,
         return window_max
     else:
 
-        if npy_isnan(window_max):
+        if npy_isnan(window_max) or (window_max == -1e9):
             return nodata
         else:
             return window_max

--- a/src/geowombat/radiometry/sr.py
+++ b/src/geowombat/radiometry/sr.py
@@ -564,7 +564,6 @@ class LinearAdjustments(object):
 
         # Set 'no data' as nans
         data = data.where(data != src_nodata)
-
         if scale_factor == 1.0:
             scale_factor = data.gw.scale_factor
 
@@ -573,7 +572,6 @@ class LinearAdjustments(object):
             data = data * scale_factor
 
         if not band_names:
-
             band_names = data.band.values.tolist()
 
             if band_names[0] == 1:

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,7 +1,8 @@
 import unittest
+import warnings
 
-import numpy as np
 import geopandas as gpd
+import numpy as np
 
 import geowombat as gw
 from geowombat.data import (
@@ -22,37 +23,42 @@ class TestClip(unittest.TestCase):
             self.assertEqual(src_clip.crs, src.crs)
 
     def test_clip_data(self):
-        with gw.open(l8_224077_20200518_B2, chunks=64) as src:
-            src_crs = src.crs
-            src_clip = gw.clip_by_polygon(src, l8_224078_20200518_polygons)
-            src_clip_mask = gw.clip_by_polygon(
-                src, l8_224078_20200518_polygons, mask_data=True
-            )
-        df = gpd.read_file(l8_224078_20200518_polygons)
-        df = df.to_crs(src_crs)
-        with gw.config.update(
-            ref_bounds=df.total_bounds.tolist(), ref_tar=l8_224077_20200518_B2
-        ):
-            with gw.open(l8_224077_20200518_B2, chunks=64) as ref:
-                self.assertTrue(
-                    np.allclose(ref.data.compute(), src_clip.data.compute())
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            with gw.open(l8_224077_20200518_B2, chunks=64) as src:
+                src_crs = src.crs
+                src_clip = gw.clip_by_polygon(src, l8_224078_20200518_polygons)
+                src_clip_mask = gw.clip_by_polygon(
+                    src, l8_224078_20200518_polygons, mask_data=True
                 )
-                # Masked data have different values
-                self.assertFalse(
-                    np.allclose(
-                        ref.data.compute(), src_clip_mask.data.compute()
+            df = gpd.read_file(l8_224078_20200518_polygons)
+            df = df.to_crs(src_crs)
+            with gw.config.update(
+                ref_bounds=df.total_bounds.tolist(),
+                ref_tar=l8_224077_20200518_B2,
+            ):
+                with gw.open(l8_224077_20200518_B2, chunks=64) as ref:
+                    self.assertTrue(
+                        np.allclose(
+                            ref.data.compute(), src_clip.data.compute()
+                        )
                     )
-                )
-                # Masked data null values should equal polygon null values
-                poly = gw.polygon_to_array(
-                    l8_224078_20200518_polygons, data=ref
-                )
-                poly_mask = poly.where(lambda x: x == 1)
-                res = src_clip_mask * poly_mask
-                self.assertTrue(
-                    res.isnull().sum().data.compute()
-                    == poly_mask.isnull().sum().data.compute()
-                )
+                    # Masked data have different values
+                    self.assertFalse(
+                        np.allclose(
+                            ref.data.compute(), src_clip_mask.data.compute()
+                        )
+                    )
+                    # Masked data null values should equal polygon null values
+                    poly = gw.polygon_to_array(
+                        l8_224078_20200518_polygons, data=ref
+                    )
+                    poly_mask = poly.where(lambda x: x == 1)
+                    res = src_clip_mask * poly_mask
+                    self.assertTrue(
+                        res.isnull().sum().data.compute()
+                        == poly_mask.isnull().sum().data.compute()
+                    )
 
 
 if __name__ == '__main__':

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 import geopandas as gpd
 import numpy as np
@@ -23,42 +22,38 @@ class TestClip(unittest.TestCase):
             self.assertEqual(src_clip.crs, src.crs)
 
     def test_clip_data(self):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
-            with gw.open(l8_224077_20200518_B2, chunks=64) as src:
-                src_crs = src.crs
-                src_clip = gw.clip_by_polygon(src, l8_224078_20200518_polygons)
-                src_clip_mask = gw.clip_by_polygon(
-                    src, l8_224078_20200518_polygons, mask_data=True
+        with gw.open(l8_224077_20200518_B2, chunks=64) as src:
+            src_crs = src.crs
+            src_clip = gw.clip_by_polygon(src, l8_224078_20200518_polygons)
+            src_clip_mask = gw.clip_by_polygon(
+                src, l8_224078_20200518_polygons, mask_data=True
+            )
+        df = gpd.read_file(l8_224078_20200518_polygons)
+        df = df.to_crs(src_crs)
+        with gw.config.update(
+            ref_bounds=df.total_bounds.tolist(),
+            ref_tar=l8_224077_20200518_B2,
+        ):
+            with gw.open(l8_224077_20200518_B2, chunks=64) as ref:
+                self.assertTrue(
+                    np.allclose(ref.data.compute(), src_clip.data.compute())
                 )
-            df = gpd.read_file(l8_224078_20200518_polygons)
-            df = df.to_crs(src_crs)
-            with gw.config.update(
-                ref_bounds=df.total_bounds.tolist(),
-                ref_tar=l8_224077_20200518_B2,
-            ):
-                with gw.open(l8_224077_20200518_B2, chunks=64) as ref:
-                    self.assertTrue(
-                        np.allclose(
-                            ref.data.compute(), src_clip.data.compute()
-                        )
+                # Masked data have different values
+                self.assertFalse(
+                    np.allclose(
+                        ref.data.compute(), src_clip_mask.data.compute()
                     )
-                    # Masked data have different values
-                    self.assertFalse(
-                        np.allclose(
-                            ref.data.compute(), src_clip_mask.data.compute()
-                        )
-                    )
-                    # Masked data null values should equal polygon null values
-                    poly = gw.polygon_to_array(
-                        l8_224078_20200518_polygons, data=ref
-                    )
-                    poly_mask = poly.where(lambda x: x == 1)
-                    res = src_clip_mask * poly_mask
-                    self.assertTrue(
-                        res.isnull().sum().data.compute()
-                        == poly_mask.isnull().sum().data.compute()
-                    )
+                )
+                # Masked data null values should equal polygon null values
+                poly = gw.polygon_to_array(
+                    l8_224078_20200518_polygons, data=ref
+                )
+                poly_mask = poly.where(lambda x: x == 1)
+                res = src_clip_mask * poly_mask
+                self.assertTrue(
+                    res.isnull().sum().data.compute()
+                    == poly_mask.isnull().sum().data.compute()
+                )
 
 
 if __name__ == '__main__':

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,33 +1,41 @@
 import unittest
 
-import geowombat as gw
-from geowombat.data import l8_224078_20200518
-from geowombat.data import l8_224077_20200518_B2
-from geowombat.data import rgbn
-
 from pyproj import CRS
 from testfixtures import LogCapture
+
+import geowombat as gw
+from geowombat.data import l8_224077_20200518_B2, l8_224078_20200518, rgbn
 
 
 class TestConfig(unittest.TestCase):
     def test_config_bands(self):
         with gw.open(l8_224078_20200518) as src:
-            self.assertEqual(','.join(map(str, src.band.values.tolist())), '1,2,3')
+            self.assertEqual(
+                ','.join(map(str, src.band.values.tolist())), '1,2,3'
+            )
 
     def test_config_bands_set_none(self):
         with gw.config.update(sensor=None):
             with gw.open(l8_224078_20200518) as src:
-                self.assertEqual(','.join(map(str, src.band.values.tolist())), '1,2,3')
+                self.assertEqual(
+                    ','.join(map(str, src.band.values.tolist())), '1,2,3'
+                )
 
     def test_config_bands_set(self):
         with gw.config.update(sensor='bgr'):
             with gw.open(l8_224078_20200518) as src:
-                self.assertEqual(','.join(src.band.values.tolist()), 'blue,green,red')
+                self.assertEqual(
+                    ','.join(src.band.values.tolist()), 'blue,green,red'
+                )
 
     def test_config_bands_set_override(self):
         with gw.config.update(sensor='bgr'):
-            with gw.open(l8_224078_20200518, band_names=['b1', 'b2', 'b3']) as src:
-                self.assertEqual(','.join(src.band.values.tolist()), 'b1,b2,b3')
+            with gw.open(
+                l8_224078_20200518, band_names=['b1', 'b2', 'b3']
+            ) as src:
+                self.assertEqual(
+                    ','.join(src.band.values.tolist()), 'b1,b2,b3'
+                )
 
     def test_config_defaults(self):
         with gw.open(l8_224078_20200518) as src:
@@ -100,7 +108,9 @@ class TestConfig(unittest.TestCase):
         filenames = [l8_224078_20200518, l8_224078_20200518]
         with gw.config.update(ref_image=l8_224077_20200518_B2):
             with gw.open(
-                filenames, band_names=['blue', 'green', 'red'], time_names=['t1', 't2']
+                filenames,
+                band_names=['blue', 'green', 'red'],
+                time_names=['t1', 't2'],
             ) as src:
                 self.assertTrue(src.crs, 32621)
                 self.assertTrue(test_crs, src.gw.crs_to_pyproj)
@@ -108,12 +118,16 @@ class TestConfig(unittest.TestCase):
     def test_unique_crs(self):
         proj4 = "+proj=aea +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-96 +x_0=0 +y_0=0 +datum=NAD83 +units=m +no_defs"
         with gw.open(rgbn, chunks={'band': -1, 'y': 64, 'x': 64}) as src:
-            dst = src.gw.transform_crs(proj4, dst_res=(10, 10), resampling='bilinear')
+            dst = src.gw.transform_crs(
+                proj4, dst_res=(10, 10), resampling='bilinear'
+            )
             self.assertEqual(dst.crs, proj4)
             self.assertEqual(dst.gw.crs_to_pyproj, proj4)
             self.assertEqual(dst.data.chunksize, (src.gw.nbands, 64, 64))
             self.assertEqual(dst.gw.celly, 10.0)
-            dst = dst.gw.transform_crs(src.crs, dst_res=(5, 5), resampling='bilinear')
+            dst = dst.gw.transform_crs(
+                src.crs, dst_res=(5, 5), resampling='bilinear'
+            )
             self.assertEqual(dst.gw.celly, 5.0)
             self.assertEqual(dst.gw.crs_to_pyproj, src.crs)
 

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -1,22 +1,37 @@
-import unittest
+import shutil
 import tempfile
+import unittest
 from pathlib import Path
 
-from geowombat.data import l8_224077_20200518_B2
 from geowombat.backends.gdal_ import warp
+from geowombat.data import l8_224077_20200518_B2
 
 
 class TestGDALWarp(unittest.TestCase):
     def test_gdal_warp(self):
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / 'tmp.tif'
+            out_path2 = Path(tmp) / 'tmp2.tif'
+            if out_path.is_file():
+                out_path.unlink()
             warp(
                 l8_224077_20200518_B2,
                 out_path,
-                overwrite=True,
                 width=10,
                 height=10,
             )
+            self.assertTrue(out_path.is_file())
+            shutil.copy(str(out_path), str(out_path2))
+            warp(
+                out_path,
+                out_path2,
+                overwrite=True,
+                width=10,
+                height=10,
+                delete_input=True,
+            )
+            self.assertFalse(out_path.is_file())
+            self.assertTrue(out_path2.is_file())
 
 
 if __name__ == '__main__':

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,6 +1,5 @@
 import datetime
 import unittest
-import warnings
 
 import numpy as np
 
@@ -27,17 +26,15 @@ class TestLoad(unittest.TestCase):
             slice(0, 64),
             slice(0, 64),
         )
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', ResourceWarning)
-            dates, y = gw.load(
-                IMAGE_LIST,
-                IMAGE_DATES,
-                ['blue'],
-                chunks={'band': -1, 'y': 64, 'x': 64},
-                nodata=65535,
-                data_slice=data_slice,
-                num_workers=1,
-            )
+        dates, y = gw.load(
+            IMAGE_LIST,
+            IMAGE_DATES,
+            ['blue'],
+            chunks={'band': -1, 'y': 64, 'x': 64},
+            nodata=65535,
+            data_slice=data_slice,
+            num_workers=1,
+        )
 
         self.assertTrue(isinstance(y, np.ndarray))
         self.assertEqual(y.shape, (3, 1, 64, 64))

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,20 +1,21 @@
-import unittest
 import datetime
+import unittest
+import warnings
+
+import numpy as np
 
 import geowombat as gw
 from geowombat.data import l3b_s2b_00390821jxn0l2a_20210319_20220730_c01
-import numpy as np
-
 
 IMAGE_LIST = [
     l3b_s2b_00390821jxn0l2a_20210319_20220730_c01,
     l3b_s2b_00390821jxn0l2a_20210319_20220730_c01,
-    l3b_s2b_00390821jxn0l2a_20210319_20220730_c01
+    l3b_s2b_00390821jxn0l2a_20210319_20220730_c01,
 ]
 IMAGE_DATES = [
     datetime.datetime(2020, 5, 18, 0, 0),
     datetime.datetime(2020, 6, 18, 0, 0),
-    datetime.datetime(2020, 7, 18, 0, 0)
+    datetime.datetime(2020, 7, 18, 0, 0),
 ]
 
 
@@ -24,17 +25,19 @@ class TestLoad(unittest.TestCase):
             slice(0, None),
             slice(0, None),
             slice(0, 64),
-            slice(0, 64)
+            slice(0, 64),
         )
-        dates, y = gw.load(
-            IMAGE_LIST,
-            IMAGE_DATES,
-            ['blue'],
-            chunks={'band': -1, 'y': 64, 'x': 64},
-            nodata=65535,
-            data_slice=data_slice,
-            num_workers=1
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', ResourceWarning)
+            dates, y = gw.load(
+                IMAGE_LIST,
+                IMAGE_DATES,
+                ['blue'],
+                chunks={'band': -1, 'y': 64, 'x': 64},
+                nodata=65535,
+                data_slice=data_slice,
+                num_workers=1,
+            )
 
         self.assertTrue(isinstance(y, np.ndarray))
         self.assertEqual(y.shape, (3, 1, 64, 64))

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -164,8 +164,7 @@ class TestConfig(unittest.TestCase):
 
         self.assertTrue(np.allclose(y1.values, y2.values, equal_nan=True))
 
-    def test_classes_match_prediction(self):
-
+    def test_classes_match_prediction_a(self):
         with gw.config.update(
             ref_res=300,
         ):
@@ -185,6 +184,34 @@ class TestConfig(unittest.TestCase):
                     len(np.unique(y1.values))
                     == len(np.unique(aoi_point["lc"])),
                     len(np.unique(y2.values))
+                    == len(np.unique(aoi_point["lc"])),
+                ]
+            )
+        )
+
+    def test_classes_match_prediction_b(self):
+        with gw.config.update(
+            ref_res=300,
+        ):
+            with gw.open(l8_224078_20200518) as src:
+                with warnings.catch_warnings():
+                    warnings.simplefilter(
+                        'ignore',
+                        (DeprecationWarning, FutureWarning, UserWarning),
+                    )
+                    X, Xy, clf = fit(src, pl_wo_feat, aoi_point, col="lc")
+                    y1 = predict(src, X, clf)
+                    y2 = fit_predict(src, pl_wo_feat, aoi_point, col="lc")
+
+        y1values = np.unique(y1.values)
+        y2values = np.unique(y2.values)
+
+        self.assertTrue(
+            np.all(
+                [
+                    len(y1values[np.isfinite(y1values)])
+                    == len(np.unique(aoi_point["lc"])),
+                    len(y2values[np.isfinite(y2values)])
                     == len(np.unique(aoi_point["lc"])),
                 ]
             )

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,25 +1,27 @@
 import unittest
+import warnings
+
+import geopandas as gpd
+import numpy as np
+from sklearn.cluster import KMeans
+from sklearn.decomposition import PCA
+
+# from sklearn.model_selection import GridSearchCV, KFold
+from sklearn.naive_bayes import GaussianNB
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import LabelEncoder, StandardScaler
+
+# from sklearn_xarray.model_selection import CrossValidatorWrapper
+# from sklearn_xarray.preprocessing import Featurizer
+from xarray import DataArray as xr_da
 
 import geowombat as gw
 from geowombat.data import (
+    l8_224078_20200518,
     l8_224078_20200518_points,
     l8_224078_20200518_polygons,
-    l8_224078_20200518,
 )
-from geowombat.ml import fit, predict, fit_predict
-
-import numpy as np
-import geopandas as gpd
-from sklearn.preprocessing import LabelEncoder
-from sklearn_xarray.preprocessing import Featurizer
-from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import LabelEncoder, StandardScaler
-from sklearn.decomposition import PCA
-from sklearn.naive_bayes import GaussianNB
-from sklearn.cluster import KMeans
-from sklearn.model_selection import GridSearchCV, KFold
-from sklearn_xarray.model_selection import CrossValidatorWrapper
-from xarray import DataArray as xr_da
+from geowombat.ml import fit, fit_predict, predict
 
 aoi_point = gpd.read_file(l8_224078_20200518_points)
 aoi_point["lc"] = LabelEncoder().fit_transform(aoi_point.name)
@@ -28,7 +30,6 @@ aoi_point = aoi_point.drop(columns=["name"])
 aoi_poly = gpd.read_file(l8_224078_20200518_polygons)
 aoi_poly["lc"] = LabelEncoder().fit_transform(aoi_poly.name)
 aoi_poly = aoi_poly.drop(columns=["name"])
-
 
 pl_wo_feat = Pipeline(
     [
@@ -59,20 +60,29 @@ class TestConfig(unittest.TestCase):
             ref_res=300,
         ):
             with gw.open(l8_224078_20200518, nodata=0) as src:
-                X, Xy, clf = fit(src, pl_wo_feat, aoi_poly, col="lc")
-                y1 = predict(src, X, clf)
-                y2 = fit_predict(src, pl_wo_feat, aoi_poly, col="lc")
+                with warnings.catch_warnings():
+                    warnings.simplefilter(
+                        'ignore',
+                        (DeprecationWarning, FutureWarning, UserWarning),
+                    )
+                    X, Xy, clf = fit(src, pl_wo_feat, aoi_poly, col="lc")
+                    y1 = predict(src, X, clf)
+                    y2 = fit_predict(src, pl_wo_feat, aoi_poly, col="lc")
 
         self.assertTrue(np.all(np.isnan(y1.values[0, 0:5, 0])))
         self.assertTrue(np.all(np.isnan(y2.values[0, 0:5, 0])))
         self.assertTrue(
             np.allclose(
-                y1.values[0, -5:-1, 0], np.array([2.0, 2.0, 3.0, 3.0]), equal_nan=True
+                y1.values[0, -5:-1, 0],
+                np.array([2.0, 2.0, 3.0, 3.0]),
+                equal_nan=True,
             )
         )
         self.assertTrue(
             np.allclose(
-                y2.values[0, -5:-1, 0], np.array([2.0, 2.0, 3.0, 3.0]), equal_nan=True
+                y2.values[0, -5:-1, 0],
+                np.array([2.0, 2.0, 3.0, 3.0]),
+                equal_nan=True,
             )
         )
 
@@ -82,9 +92,14 @@ class TestConfig(unittest.TestCase):
             ref_res=300,
         ):
             with gw.open(l8_224078_20200518, nodata=0) as src:
-                X, Xy, clf = fit(src, pl_wo_feat, aoi_poly, col="lc")
-                y1 = predict(src, X, clf)
-                y2 = fit_predict(src, pl_wo_feat, aoi_poly, col="lc")
+                with warnings.catch_warnings():
+                    warnings.simplefilter(
+                        'ignore',
+                        (DeprecationWarning, FutureWarning, UserWarning),
+                    )
+                    X, Xy, clf = fit(src, pl_wo_feat, aoi_poly, col="lc")
+                    y1 = predict(src, X, clf)
+                    y2 = fit_predict(src, pl_wo_feat, aoi_poly, col="lc")
 
         self.assertTrue(isinstance(y1, xr_da))
         self.assertTrue(isinstance(y2, xr_da))
@@ -98,9 +113,14 @@ class TestConfig(unittest.TestCase):
             ref_res=300,
         ):
             with gw.open(l8_224078_20200518, nodata=0) as src:
-                X, Xy, clf = fit(src, pl_wo_feat, aoi_point, col="lc")
-                y1 = predict(src, X, clf)
-                y2 = fit_predict(src, pl_wo_feat, aoi_point, col="lc")
+                with warnings.catch_warnings():
+                    warnings.simplefilter(
+                        'ignore',
+                        (DeprecationWarning, FutureWarning, UserWarning),
+                    )
+                    X, Xy, clf = fit(src, pl_wo_feat, aoi_point, col="lc")
+                    y1 = predict(src, X, clf)
+                    y2 = fit_predict(src, pl_wo_feat, aoi_point, col="lc")
 
         self.assertTrue(np.allclose(y1.values, y2.values, equal_nan=True))
 
@@ -112,9 +132,18 @@ class TestConfig(unittest.TestCase):
             with gw.open(
                 [l8_224078_20200518, l8_224078_20200518], stack_dim="time"
             ) as src:
-                y1 = fit_predict(
-                    src, pl_wo_feat, aoi_point, col="lc", mask_nodataval=False
-                )
+                with warnings.catch_warnings():
+                    warnings.simplefilter(
+                        'ignore',
+                        (DeprecationWarning, FutureWarning, UserWarning),
+                    )
+                    y1 = fit_predict(
+                        src,
+                        pl_wo_feat,
+                        aoi_point,
+                        col="lc",
+                        mask_nodataval=False,
+                    )
 
         self.assertTrue(np.all(y1.sel(time=1).values == y1.sel(time=2).values))
 
@@ -124,9 +153,14 @@ class TestConfig(unittest.TestCase):
             ref_res=300,
         ):
             with gw.open(l8_224078_20200518, nodata=0) as src:
-                X, Xy, clf = fit(data=src, clf=cl_wo_feat)
-                y1 = predict(src, X, clf)
-                y2 = fit_predict(data=src, clf=cl_wo_feat)
+                with warnings.catch_warnings():
+                    warnings.simplefilter(
+                        'ignore',
+                        (DeprecationWarning, FutureWarning, UserWarning),
+                    )
+                    X, Xy, clf = fit(data=src, clf=cl_wo_feat)
+                    y1 = predict(src, X, clf)
+                    y2 = fit_predict(data=src, clf=cl_wo_feat)
 
         self.assertTrue(np.allclose(y1.values, y2.values, equal_nan=True))
 
@@ -136,38 +170,21 @@ class TestConfig(unittest.TestCase):
             ref_res=300,
         ):
             with gw.open(l8_224078_20200518) as src:
-                X, Xy, clf = fit(src, pl_wo_feat, aoi_point, col="lc")
-                y1 = predict(src, X, clf)
-                y2 = fit_predict(src, pl_wo_feat, aoi_point, col="lc")
+                with warnings.catch_warnings():
+                    warnings.simplefilter(
+                        'ignore',
+                        (DeprecationWarning, FutureWarning, UserWarning),
+                    )
+                    X, Xy, clf = fit(src, pl_wo_feat, aoi_point, col="lc")
+                    y1 = predict(src, X, clf)
+                    y2 = fit_predict(src, pl_wo_feat, aoi_point, col="lc")
 
         self.assertTrue(
             np.all(
                 [
-                    len(np.unique(y1.values)) == len(np.unique(aoi_point["lc"])),
-                    len(np.unique(y2.values)) == len(np.unique(aoi_point["lc"])),
-                ]
-            )
-        )
-
-    def test_classes_match_prediction(self):
-
-        with gw.config.update(
-            ref_res=300,
-        ):
-            with gw.open(l8_224078_20200518) as src:
-                X, Xy, clf = fit(src, pl_wo_feat, aoi_point, col="lc")
-                y1 = predict(src, X, clf)
-                y2 = fit_predict(src, pl_wo_feat, aoi_point, col="lc")
-
-        y1values = np.unique(y1.values)
-        y2values = np.unique(y2.values)
-
-        self.assertTrue(
-            np.all(
-                [
-                    len(y1values[np.isfinite(y1values)])
+                    len(np.unique(y1.values))
                     == len(np.unique(aoi_point["lc"])),
-                    len(y2values[np.isfinite(y2values)])
+                    len(np.unique(y2.values))
                     == len(np.unique(aoi_point["lc"])),
                 ]
             )

--- a/tests/test_moving.py
+++ b/tests/test_moving.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 import xarray as xr
 
@@ -9,64 +8,52 @@ from geowombat.data import l8_224078_20200518
 
 class TestMoving(unittest.TestCase):
     def moving_func(self, src: xr.DataArray, stat: str):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            # 3x3 window
-            res_3x3 = src.gw.moving(
-                stat=stat,
-                w=3,
-                nodata=0,
+        # 3x3 window
+        res_3x3 = src.gw.moving(
+            stat=stat,
+            w=3,
+            nodata=0,
+        )
+        # 5x5 window
+        res_5x5 = src.gw.moving(
+            stat=stat,
+            w=5,
+            nodata=0,
+        )
+
+        for band in res_3x3.band.values:
+            ref_array = src.where(lambda x: x != 0).sel(band=band)
+
+            ref_band1_value = float(
+                getattr(ref_array[100:103, 100:103], stat)(skipna=True)
+                .fillna(0)
+                .data.compute()
             )
-            # 5x5 window
-            res_5x5 = src.gw.moving(
-                stat=stat,
-                w=5,
-                nodata=0,
+            tar_band1_value = res_3x3.sel(band=band)[101, 101].data.compute()
+            self.assertAlmostEqual(ref_band1_value, tar_band1_value, places=4)
+            self.assertEqual(src.shape, res_3x3.shape)
+
+        for band in res_5x5.band.values:
+            ref_array = src.where(lambda x: x != 0).sel(band=band)
+            ref_band1_value = float(
+                getattr(ref_array[100:105, 100:105], stat)(skipna=True)
+                .fillna(0)
+                .data.compute()
             )
+            tar_band1_value = res_5x5.sel(band=band)[102, 102].data.compute()
 
-            for band in res_3x3.band.values:
-                ref_array = src.where(lambda x: x != 0).sel(band=band)
+            self.assertAlmostEqual(ref_band1_value, tar_band1_value, places=4)
+            self.assertEqual(src.shape, res_5x5.shape)
 
-                ref_band1_value = float(
-                    getattr(ref_array[100:103, 100:103], stat)(skipna=True)
-                    .fillna(0)
-                    .data.compute()
-                )
-                tar_band1_value = res_3x3.sel(band=band)[
-                    101, 101
-                ].data.compute()
-                self.assertAlmostEqual(
-                    ref_band1_value, tar_band1_value, places=4
-                )
-                self.assertEqual(src.shape, res_3x3.shape)
+            # Check along chunk border
+            ref_band1_value = float(
+                getattr(ref_array[:5, 127:132], stat)(skipna=True)
+                .fillna(0)
+                .data.compute()
+            )
+            tar_band1_value = res_5x5.sel(band=band)[2, 129].data.compute()
 
-            for band in res_5x5.band.values:
-                ref_array = src.where(lambda x: x != 0).sel(band=band)
-                ref_band1_value = float(
-                    getattr(ref_array[100:105, 100:105], stat)(skipna=True)
-                    .fillna(0)
-                    .data.compute()
-                )
-                tar_band1_value = res_5x5.sel(band=band)[
-                    102, 102
-                ].data.compute()
-
-                self.assertAlmostEqual(
-                    ref_band1_value, tar_band1_value, places=4
-                )
-                self.assertEqual(src.shape, res_5x5.shape)
-
-                # Check along chunk border
-                ref_band1_value = float(
-                    getattr(ref_array[:5, 127:132], stat)(skipna=True)
-                    .fillna(0)
-                    .data.compute()
-                )
-                tar_band1_value = res_5x5.sel(band=band)[2, 129].data.compute()
-
-                self.assertAlmostEqual(
-                    ref_band1_value, tar_band1_value, places=4
-                )
+            self.assertAlmostEqual(ref_band1_value, tar_band1_value, places=4)
 
     def test_moving_mean(self):
         with gw.open(l8_224078_20200518, chunks=128) as src:

--- a/tests/test_moving.py
+++ b/tests/test_moving.py
@@ -1,0 +1,38 @@
+import unittest
+
+import geowombat as gw
+from geowombat.data import l8_224078_20200518
+
+
+class TestMoving(unittest.TestCase):
+    def test_moving(self):
+        with gw.open(l8_224078_20200518, chunks=128) as src:
+            res = src.gw.moving(
+                stat="mean",
+                w=3,
+                nodata=0,
+            )
+            ref_band1_mean = (
+                src.sel(band=1)[100:103, 100:103].mean().data.compute()
+            )
+            tar_band1_mean = res.sel(band=1)[101, 101].data.compute()
+
+            self.assertEqual(ref_band1_mean, tar_band1_mean)
+            self.assertEqual(src.shape, res.shape)
+
+            res = src.gw.moving(
+                stat="mean",
+                w=5,
+                nodata=0,
+            )
+            ref_band1_mean = (
+                src.sel(band=1)[100:105, 100:105].mean().data.compute()
+            )
+            tar_band1_mean = res.sel(band=1)[102, 102].data.compute()
+
+            self.assertEqual(ref_band1_mean, tar_band1_mean)
+            self.assertEqual(src.shape, res.shape)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_moving.py
+++ b/tests/test_moving.py
@@ -1,37 +1,92 @@
 import unittest
+import warnings
+
+import xarray as xr
 
 import geowombat as gw
 from geowombat.data import l8_224078_20200518
 
 
 class TestMoving(unittest.TestCase):
-    def test_moving(self):
-        with gw.open(l8_224078_20200518, chunks=128) as src:
-            res = src.gw.moving(
-                stat="mean",
+    def moving_func(self, src: xr.DataArray, stat: str):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            # 3x3 window
+            res_3x3 = src.gw.moving(
+                stat=stat,
                 w=3,
                 nodata=0,
             )
-            ref_band1_mean = (
-                src.sel(band=1)[100:103, 100:103].mean().data.compute()
-            )
-            tar_band1_mean = res.sel(band=1)[101, 101].data.compute()
-
-            self.assertEqual(ref_band1_mean, tar_band1_mean)
-            self.assertEqual(src.shape, res.shape)
-
-            res = src.gw.moving(
-                stat="mean",
+            # 5x5 window
+            res_5x5 = src.gw.moving(
+                stat=stat,
                 w=5,
                 nodata=0,
             )
-            ref_band1_mean = (
-                src.sel(band=1)[100:105, 100:105].mean().data.compute()
-            )
-            tar_band1_mean = res.sel(band=1)[102, 102].data.compute()
 
-            self.assertEqual(ref_band1_mean, tar_band1_mean)
-            self.assertEqual(src.shape, res.shape)
+            for band in res_3x3.band.values:
+                ref_array = src.where(lambda x: x != 0).sel(band=band)
+
+                ref_band1_value = float(
+                    getattr(ref_array[100:103, 100:103], stat)(skipna=True)
+                    .fillna(0)
+                    .data.compute()
+                )
+                tar_band1_value = res_3x3.sel(band=band)[
+                    101, 101
+                ].data.compute()
+                self.assertAlmostEqual(
+                    ref_band1_value, tar_band1_value, places=4
+                )
+                self.assertEqual(src.shape, res_3x3.shape)
+
+            for band in res_5x5.band.values:
+                ref_array = src.where(lambda x: x != 0).sel(band=band)
+                ref_band1_value = float(
+                    getattr(ref_array[100:105, 100:105], stat)(skipna=True)
+                    .fillna(0)
+                    .data.compute()
+                )
+                tar_band1_value = res_5x5.sel(band=band)[
+                    102, 102
+                ].data.compute()
+
+                self.assertAlmostEqual(
+                    ref_band1_value, tar_band1_value, places=4
+                )
+                self.assertEqual(src.shape, res_5x5.shape)
+
+                # Check along chunk border
+                ref_band1_value = float(
+                    getattr(ref_array[:5, 127:132], stat)(skipna=True)
+                    .fillna(0)
+                    .data.compute()
+                )
+                tar_band1_value = res_5x5.sel(band=band)[2, 129].data.compute()
+
+                self.assertAlmostEqual(
+                    ref_band1_value, tar_band1_value, places=4
+                )
+
+    def test_moving_mean(self):
+        with gw.open(l8_224078_20200518, chunks=128) as src:
+            self.moving_func(src, stat="mean")
+
+    def test_moving_min(self):
+        with gw.open(l8_224078_20200518, chunks=128) as src:
+            self.moving_func(src, stat="min")
+
+    def test_moving_max(self):
+        with gw.open(l8_224078_20200518, chunks=128) as src:
+            self.moving_func(src, stat="max")
+
+    def test_moving_var(self):
+        with gw.open(l8_224078_20200518, chunks=128) as src:
+            self.moving_func(src, stat="var")
+
+    def test_moving_std(self):
+        with gw.open(l8_224078_20200518, chunks=128) as src:
+            self.moving_func(src, stat="std")
 
 
 if __name__ == '__main__':

--- a/tests/test_rasterio.py
+++ b/tests/test_rasterio.py
@@ -119,7 +119,7 @@ class TestRasterio(unittest.TestCase):
         self.assertEqual(check_res((10, 10)), (10.0, 10.0))
 
         with self.assertRaises(TypeError):
-            check_res({10}), (10.0, 10.0)
+            check_res({10})
 
     def test_unpack_bounding_box(self):
         bounds = 'BoundingBox(left=-100, bottom=-100, right=100, top=100)'

--- a/tests/test_rasterio.py
+++ b/tests/test_rasterio.py
@@ -1,17 +1,18 @@
 import unittest
 
-from geowombat.data import l8_224077_20200518_B2
-from geowombat.backends.rasterio_ import (
-    get_dims_from_bounds,
-    get_file_info,
-    check_res,
-    unpack_bounding_box,
-    unpack_window,
-)
-
 import rasterio as rio
 from rasterio.coords import BoundingBox
 from rasterio.windows import Window
+
+from geowombat.backends.rasterio_ import (
+    check_res,
+    get_dims_from_bounds,
+    get_file_info,
+    unpack_bounding_box,
+    unpack_window,
+    window_to_bounds,
+)
+from geowombat.data import l8_224077_20200518_B2
 
 
 class TestRasterio(unittest.TestCase):
@@ -53,6 +54,18 @@ class TestRasterio(unittest.TestCase):
         converted_window = unpack_window(window)
         ref_window = Window(col_off=0, row_off=0, width=100, height=100)
         self.assertEqual(ref_window, converted_window)
+
+    def test_window_to_bounds(self):
+        w = Window(col_off=0, row_off=0, width=100, height=100)
+        with rio.open(l8_224077_20200518_B2) as src:
+            bounds = window_to_bounds(l8_224077_20200518_B2, w=w)
+            ref_bounds = (
+                src.bounds.left,
+                src.bounds.top - (100 * src.res[0]),
+                src.bounds.left + (100 * src.res[0]),
+                src.bounds.top,
+            )
+            self.assertEqual(bounds, ref_bounds)
 
 
 if __name__ == '__main__':

--- a/tests/test_rasterio.py
+++ b/tests/test_rasterio.py
@@ -1,5 +1,4 @@
 import unittest
-import warnings
 
 import numpy as np
 import rasterio as rio
@@ -77,11 +76,9 @@ class TestRasterio(unittest.TestCase):
     def test_check_crs(self):
         with rio.open(l8_224077_20200518_B2) as src:
             self.assertEqual(check_crs(src.crs), CRS.from_epsg(32621))
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', FutureWarning)
-                self.assertEqual(
-                    check_crs(src.crs.to_dict()), CRS.from_epsg(32621)
-                )
+            self.assertEqual(
+                check_crs(src.crs.to_dict()), CRS.from_epsg(32621)
+            )
             self.assertEqual(
                 check_crs(src.crs.to_proj4()), CRS.from_epsg(32621)
             )

--- a/tests/test_rasterio.py
+++ b/tests/test_rasterio.py
@@ -34,10 +34,9 @@ class TestRasterio(unittest.TestCase):
             transform, Affine(2.0, 0.0, -100.0, 0.0, -2.0, 100.0)
         )
 
-        with self.assertRaises(TypeError):
-            transform, width, height = align_bounds(
-                -100.0, -100.0, 100.0, 100.0, {2.0}
-            )
+        self.assertRaises(
+            TypeError, align_bounds, -100.0, -100.0, 100.0, 100.0, {2.0}
+        )
 
         transform, width, height = align_bounds(
             -100.0, -100.0, 100.0, 100.0, 2.0
@@ -94,12 +93,9 @@ class TestRasterio(unittest.TestCase):
             )
 
         self.assertEqual(check_crs(4326), CRS.from_epsg(4326))
-        with self.assertRaises(ValueError):
-            crs = check_crs(4325)
-        with self.assertRaises(ValueError):
-            crs = check_crs("cat")
-        with self.assertRaises(TypeError):
-            crs = check_crs(np.ones(1))
+        self.assertRaises(ValueError, check_crs, 4325)
+        self.assertRaises(ValueError, check_crs, 'cat')
+        self.assertRaises(TypeError, check_crs, np.ones(1))
 
     def test_check_file_crs(self):
         crs = check_file_crs(
@@ -117,9 +113,7 @@ class TestRasterio(unittest.TestCase):
         self.assertEqual(check_res(10.0), (10.0, 10.0))
         self.assertEqual(check_res(10), (10.0, 10.0))
         self.assertEqual(check_res((10, 10)), (10.0, 10.0))
-
-        with self.assertRaises(TypeError):
-            check_res({10})
+        self.assertRaises(TypeError, check_res, {10})
 
     def test_unpack_bounding_box(self):
         bounds = 'BoundingBox(left=-100, bottom=-100, right=100, top=100)'

--- a/tests/test_rasterio.py
+++ b/tests/test_rasterio.py
@@ -1,10 +1,17 @@
 import unittest
+import warnings
 
+import numpy as np
 import rasterio as rio
+from affine import Affine
+from pyproj import CRS
 from rasterio.coords import BoundingBox
 from rasterio.windows import Window
 
 from geowombat.backends.rasterio_ import (
+    align_bounds,
+    check_crs,
+    check_file_crs,
     check_res,
     get_dims_from_bounds,
     get_file_info,
@@ -12,10 +19,43 @@ from geowombat.backends.rasterio_ import (
     unpack_window,
     window_to_bounds,
 )
-from geowombat.data import l8_224077_20200518_B2
+from geowombat.data import (
+    l3b_s2b_00390821jxn0l2a_20210319_20220730_c01,
+    l8_224077_20200518_B2,
+)
 
 
 class TestRasterio(unittest.TestCase):
+    def test_align_bounds(self):
+        transform, width, height = align_bounds(
+            -100.0, -100.0, 100.0, 100.0, (2.0, 2.0)
+        )
+        self.assertTupleEqual(
+            transform, Affine(2.0, 0.0, -100.0, 0.0, -2.0, 100.0)
+        )
+
+        with self.assertRaises(TypeError):
+            transform, width, height = align_bounds(
+                -100.0, -100.0, 100.0, 100.0, {2.0}
+            )
+
+        transform, width, height = align_bounds(
+            -100.0, -100.0, 100.0, 100.0, 2.0
+        )
+        self.assertTupleEqual(
+            transform, Affine(2.0, 0.0, -100.0, 0.0, -2.0, 100.0)
+        )
+
+        transform, width, height = align_bounds(
+            -100.0, -100.0, 100.0, 100.0, 1.67
+        )
+        self.assertTupleEqual(
+            transform,
+            Affine(
+                1.67, 0.0, -100.19999999999999, 0.0, -1.67, 100.19999999999999
+            ),
+        )
+
     def test_get_dims_from_bounds(self):
         bounds = BoundingBox(
             left=-100,
@@ -35,8 +75,51 @@ class TestRasterio(unittest.TestCase):
             self.assertEqual(file_info.src_height, src.height)
             self.assertEqual(file_info.src_width, src.width)
 
+    def test_check_crs(self):
+        with rio.open(l8_224077_20200518_B2) as src:
+            self.assertEqual(check_crs(src.crs), CRS.from_epsg(32621))
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', FutureWarning)
+                self.assertEqual(
+                    check_crs(src.crs.to_dict()), CRS.from_epsg(32621)
+                )
+            self.assertEqual(
+                check_crs(src.crs.to_proj4()), CRS.from_epsg(32621)
+            )
+            self.assertEqual(
+                check_crs(
+                    "+proj=utm +zone=21 +datum=WGS84 +units=m +no_defs +type=crs"
+                ),
+                CRS.from_epsg(32621),
+            )
+
+        self.assertEqual(check_crs(4326), CRS.from_epsg(4326))
+        with self.assertRaises(ValueError):
+            crs = check_crs(4325)
+        with self.assertRaises(ValueError):
+            crs = check_crs("cat")
+        with self.assertRaises(TypeError):
+            crs = check_crs(np.ones(1))
+
+    def test_check_file_crs(self):
+        crs = check_file_crs(
+            f"netcdf:{l3b_s2b_00390821jxn0l2a_20210319_20220730_c01}:blue"
+        )
+        self.assertEqual(crs, CRS.from_epsg(8858))
+
+        crs = check_file_crs(l3b_s2b_00390821jxn0l2a_20210319_20220730_c01)
+        self.assertEqual(crs, CRS.from_epsg(8858))
+
+        crs = check_file_crs(l8_224077_20200518_B2)
+        self.assertEqual(crs, CRS.from_epsg(32621))
+
     def test_check_res(self):
+        self.assertEqual(check_res(10.0), (10.0, 10.0))
         self.assertEqual(check_res(10), (10.0, 10.0))
+        self.assertEqual(check_res((10, 10)), (10.0, 10.0))
+
+        with self.assertRaises(TypeError):
+            check_res({10}), (10.0, 10.0)
 
     def test_unpack_bounding_box(self):
         bounds = 'BoundingBox(left=-100, bottom=-100, right=100, top=100)'
@@ -57,8 +140,17 @@ class TestRasterio(unittest.TestCase):
 
     def test_window_to_bounds(self):
         w = Window(col_off=0, row_off=0, width=100, height=100)
+        bounds = window_to_bounds(l8_224077_20200518_B2, w=w)
         with rio.open(l8_224077_20200518_B2) as src:
-            bounds = window_to_bounds(l8_224077_20200518_B2, w=w)
+            ref_bounds = (
+                src.bounds.left,
+                src.bounds.top - (100 * src.res[0]),
+                src.bounds.left + (100 * src.res[0]),
+                src.bounds.top,
+            )
+            self.assertEqual(bounds, ref_bounds)
+        bounds = window_to_bounds([l8_224077_20200518_B2], w=w)
+        with rio.open(l8_224077_20200518_B2) as src:
             ref_bounds = (
                 src.bounds.left,
                 src.bounds.top - (100 * src.res[0]),

--- a/tests/test_vi.py
+++ b/tests/test_vi.py
@@ -1,0 +1,106 @@
+import unittest
+
+import dask.array as da
+import numpy as np
+import xarray as xr
+
+import geowombat as gw
+
+BANDS = np.array([[[0.4]], [[0.1]]])
+
+
+def create_data(band1: str, band2: str) -> xr.DataArray:
+    return xr.DataArray(
+        da.from_array(BANDS, chunks=(-1, 1, 1)),
+        dims=('band', 'y', 'x'),
+        coords={'band': [band1, band2], 'y': [1], 'x': [1]},
+    )
+
+
+class TestVI(unittest.TestCase):
+    def test_wi(self):
+        data = create_data('red', 'swir1')
+        result = data.sel(band='red') + data.sel(band='swir1')
+        result = (1.0 - (result.where(lambda x: x <= 0.5) / 0.5)).fillna(0)
+
+        vi = data.gw.wi()
+
+        self.assertTrue(np.allclose(vi.data.compute(), result.data.compute()))
+
+    def test_kndvi(self):
+        data = create_data('red', 'nir')
+        result = (data.sel(band='nir') - data.sel(band='red')) / (
+            data.sel(band='nir') + data.sel(band='red')
+        )
+        result = np.tanh(result**2)
+
+        vi = data.gw.kndvi()
+
+        self.assertTrue(np.allclose(vi.data.compute(), result.data.compute()))
+
+    def test_ndvi(self):
+        data = create_data('red', 'nir')
+        result = (data.sel(band='nir') - data.sel(band='red')) / (
+            data.sel(band='nir') + data.sel(band='red')
+        )
+
+        vi = data.gw.ndvi()
+
+        self.assertTrue(np.allclose(vi.data.compute(), result.data.compute()))
+
+    def test_nbr(self):
+        data = create_data('nir', 'swir2')
+        result = (data.sel(band='nir') - data.sel(band='swir2')) / (
+            data.sel(band='nir') + data.sel(band='swir2')
+        )
+
+        vi = data.gw.nbr()
+
+        self.assertTrue(np.allclose(vi.data.compute(), result.data.compute()))
+
+    def test_gcvi(self):
+        data = create_data('green', 'nir')
+        result = (data.sel(band='nir') / data.sel(band='green') - 1.0).clip(
+            0, 10
+        ) / 10.0
+
+        vi = data.gw.gcvi()
+
+        self.assertTrue(np.allclose(vi.data.compute(), result.data.compute()))
+
+    def test_evi2(self):
+        data = create_data('red', 'nir')
+        result = (
+            2.5
+            * (
+                (data.sel(band='nir') - data.sel(band='red'))
+                / (data.sel(band='nir') + 1.0 + (2.4 * (data.sel(band='red'))))
+            )
+        ).clip(0, 1)
+
+        vi = data.gw.evi2()
+
+        self.assertTrue(np.allclose(vi.data.compute(), result.data.compute()))
+
+    def test_avi(self):
+        data = create_data('red', 'nir')
+        result = (
+            (
+                (
+                    data.sel(band='nir')
+                    * (1.0 - data.sel(band='red'))
+                    * (data.sel(band='nir') - data.sel(band='red'))
+                )
+                ** 0.3334
+            )
+            .fillna(0)
+            .clip(0, 1)
+        )
+
+        vi = data.gw.avi(nodata=0)
+
+        self.assertTrue(np.allclose(vi.data.compute(), result.data.compute()))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_xarray.py
+++ b/tests/test_xarray.py
@@ -1,0 +1,88 @@
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import xarray as xr
+from affine import Affine
+from dask import delayed
+
+import geowombat as gw
+from geowombat.backends.xarray_ import delayed_to_xarray
+from geowombat.data import (
+    l3b_s2b_00390821jxn0l2a_20210319_20220730_c01,
+    l8_224077_20200518_B2,
+)
+
+
+def scale(data: xr.DataArray) -> xr.DataArray:
+    return data * 1e-4
+
+
+def expand_time(dataset):
+    """`open_mfdataset` preprocess function."""
+    attrs = dataset.attrs.copy()
+    attrs['transform'] = Affine(*attrs['transform'])
+    attrs['res'] = tuple(attrs['res'])
+    # Get the date
+    file_date = datetime.strptime(
+        Path(dataset.encoding['source']).stem.split('_')[3], '%Y%m%d'
+    )
+    darray = (
+        dataset.to_array()
+        .rename({'variable': 'band'})
+        .assign_coords(time=file_date, y=dataset.y, x=dataset.x)
+        .expand_dims('time')
+        .transpose('time', 'band', 'y', 'x')
+        .where(lambda x: x != x.nodatavals[0])
+    )
+
+    return darray.map_blocks(scale, template=darray).assign_attrs(**attrs)
+
+
+class TestXarray(unittest.TestCase):
+    def test_open(self):
+        """Test to ensure dask/xarray version changes do not break behavior."""
+        n_time = 2
+        n_bands = 6
+        with xr.open_mfdataset(
+            [l3b_s2b_00390821jxn0l2a_20210319_20220730_c01] * n_time,
+            concat_dim='time',
+            chunks={
+                'time': -1,
+                'band': -1,
+                'y': 256,
+                'x': 256,
+            },
+            combine='nested',
+            engine='h5netcdf',
+            preprocess=expand_time,
+            parallel=True,
+        ) as ds:
+            self.assertEqual(ds.gw.ntime, n_time)
+            self.assertEqual(ds.gw.nbands, n_bands)
+
+    def test_delayed_to_xarray(self):
+        def random_func(bands: int, height: int, width: int) -> np.ndarray:
+            np.random.seed(100)
+            return np.random.random((bands, height, width))
+
+        with gw.open(l8_224077_20200518_B2) as src:
+            data_dst = delayed_to_xarray(
+                delayed(random_func)(
+                    src.gw.nbands, src.gw.nrows, src.gw.ncols
+                ),
+                shape=(src.gw.nbands, src.gw.nrows, src.gw.ncols),
+                dtype=src.dtype,
+                chunks=src.data.chunksize,
+                coords={
+                    'band': src.band.values.tolist(),
+                    'y': src.y,
+                    'x': src.x,
+                },
+                attrs=src.attrs,
+            )
+            ref_data = random_func(src.gw.nbands, src.gw.nrows, src.gw.ncols)
+
+            self.assertTrue(np.allclose(ref_data, data_dst.data.compute()))
+            self.assertEqual(src.shape, data_dst.shape)


### PR DESCRIPTION
## What is this PR changing?
Using multiple thread workers inside a `dask.compute` call can lead to thread race conditions. The `_moving.pyx` module can be used with multi-threading if imported directly. However, if used within `dask.map_overlap` (which is how we use it in `gw.moving` or `data.gw.moving`) then `cython` threading should be turned off.

This PR ensures that the serial version of `_moving.pyx` is used inside `gw.moving`.