### PR TITLE
jgrss/io_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](data/logo.png)
 
 [![](https://img.shields.io/badge/License-MIT-black.svg)](https://github.com/jgrss/geowombat/blob/main/LICENSE.txt)
-[![python](https://img.shields.io/badge/Python-3.7%20%7C%203.8%20%7C%203.9-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
+[![python](https://img.shields.io/badge/Python-3.8%20%7C%203.9-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
 [![](https://img.shields.io/github/v/release/jgrss/geowombat?display_name=release)](https://github.com/jgrss/geowombat/releases)
 [![](https://github.com/jgrss/geowombat/actions/workflows/ci.yml/badge.svg)](https://github.com/jgrss/geowombat/actions/)
 [![](https://img.shields.io/github/repo-size/jgrss/geowombat)](https://shields.io/category/size)

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific :: Remote Sensing
     Programming Language :: Cython
-    Programming Language :: Python :: 3.7 :: 3.8 :: 3.9
+    Programming Language :: Python :: 3.8 :: 3.9
 
 [options]
 package_dir=
@@ -24,7 +24,7 @@ packages=find:
 include_package_data = True
 setup_requires =
     cython>=0.29.0,<3.0.0
-python_requires = >=3.7,<=3.9.16
+python_requires = >=3.8,<=3.9.16
 install_requires =
     dask[array,dataframe]>=2023.1.0
     distributed>=2023.1.0

--- a/src/geowombat/backends/rasterio_.py
+++ b/src/geowombat/backends/rasterio_.py
@@ -237,12 +237,10 @@ class RasterioStore(object):
 
     def write(self, data: xr.DataArray, compute: bool = False) -> Delayed:
         if isinstance(data.data, da.Array):
-            return da.store(
-                da.squeeze(data.data), self, lock=True, compute=compute
-            )
+            return da.store(data.data, self, lock=True, compute=compute)
         else:
             self.dst.write(
-                data.squeeze().data,
+                data.data,
                 indexes=list(range(1, data.data.shape[0] + 1)),
             )
 


### PR DESCRIPTION
## What is this PR changing?
When calling `gw.save()`, image chunks <=1 get squeezed, resulting in a `ValueError: not enough values to unpack` error. This PR removes the squeeze, as it is unnecessary regardless of dimension size.