### PR TITLE
[CI test] [280] test numpy pinned at >=1.24.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     'setuptools>=59.5.0',
     'wheel',
     'Cython>=0.29.0,<3.0.0',
-    'numpy>=1.19.0'
+    'numpy>=1.24.4'
 ]
 
 [tool.black]

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,3 @@
-numpy>=1.19.0
+numpy>=1.24.4
 setuptools>=59.5.0
 ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     geopandas>=0.8.0
     joblib>=0.16.0
     matplotlib>=3.3.0
-    numpy>=1.19.0
+    numpy>=1.24.4
     pandas>=1.0.0
     pyproj>=3.0.0,<=3.4.0 # pyproj==3.5.0 raise error with WKT1_GDAL format, but we do not need Geoarray projection
     rasterio>=1.3.0,<2.0.0


### PR DESCRIPTION
## What is this PR changing?
Following #280, pins the minimum numpy version at 1.24.4.
  