### PR TITLE
jgrss/item asset timeout

### DIFF
--- a/src/geowombat/core/stac.py
+++ b/src/geowombat/core/stac.py
@@ -306,10 +306,10 @@ def open_stac(
         >>>     start_date='2020-01-01',
         >>>     end_date='2021-01-01',
         >>>     bounds='map.geojson',
-        >>>     bands=['B04', 'B03', 'B02'],
+        >>>     bands=['blue', 'green', 'red'],
         >>>     resampling=Resampling.cubic,
         >>>     epsg=int(data_l.epsg.values),
-        >>>     extra_assets=['metadata']
+        >>>     extra_assets=['granule_metadata']
         >>> )
         >>>
         >>> # Merge two temporal stacks

--- a/src/geowombat/core/stac.py
+++ b/src/geowombat/core/stac.py
@@ -195,7 +195,8 @@ def merge_stac(
     )
 
 
-def download_worker(item, extra: str, out_path: _Path) -> dict:
+def _download_worker(item, extra: str, out_path: _Path) -> dict:
+    """Downloads a single STAC item 'extra'."""
     df_dict = {'id': item.id}
     url = item.assets[extra].to_dict()['href']
     out_name = out_path / f"{item.id}_{_Path(url.split('?')[0]).name}"
@@ -415,7 +416,7 @@ def open_stac(
                 ) as executor:
                     futures = {
                         executor.submit(
-                            download_worker, item, extra, out_path
+                            _download_worker, item, extra, out_path
                         ): extra
                         for extra in extra_assets
                         for item in items


### PR DESCRIPTION
## What is this PR changing?
The timeout decorator causes hanging threads after STAC item metadata downloads.
