### PR TITLE
Simplify band mosaic procedure

### DIFF
--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,16 +1,17 @@
 import unittest
 from pathlib import Path
-
+import tempfile
 import dask
 import numpy as np
 import rasterio as rio
 import xarray as xr
 from pyproj import CRS
-
+import os 
 import geowombat as gw
 from geowombat.data import (
     l3b_s2b_00390821jxn0l2a_20210319_20220730_c01,
     l8_224077_20200518_B2,
+    l8_224078_20200518_B2,
     l8_224077_20200518_B2_60m,
     l8_224078_20200518,
 )
@@ -112,6 +113,58 @@ class TestOpen(unittest.TestCase):
             overlap='mean',
         ) as src:
             self.assertEqual(src.gw.ntime, 1)
+
+    def test_union_values(self):
+        filenames = [l8_224077_20200518_B2, l8_224078_20200518_B2]
+        with gw.open(
+            filenames,
+            band_names=['blue'],
+            mosaic=True,
+            bounds_by='union'
+        ) as src:
+            vals = src.values[0,src.shape[1]//2, src.shape[1]//2:src.shape[1]//2 +10]
+            self.assertTrue(all(vals==[8678, 8958, 8970, 8966, 8912, 8749, 8131, 7598, 7590, 7606]))
+        
+    def test_mosaic_save(self):
+        # Using a context manager for the temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            test_file_path = os.path.join(temp_dir, 'test.tif')
+            filenames = [l8_224077_20200518_B2, l8_224078_20200518_B2]  # Assuming these are correct file paths
+            try:
+                with gw.open(
+                        filenames,
+                        band_names=['blue'],
+                        mosaic=True,
+                        bounds_by='union',
+                        nodata=0
+                    ) as src:
+                    src.gw.save(test_file_path, overwrite=True)
+            except Exception as e:
+                # If any exception is raised, fail the test with a message
+                self.fail(f"An error occurred during saving: {e}")
+
+
+    def test_bounds_union(self):
+        filenames = [l8_224077_20200518_B2, l8_224078_20200518_B2]
+        with gw.open(
+            filenames,
+            band_names=['blue'],
+            mosaic=True,
+            bounds_by='union'
+        ) as src:
+            bounds = src.gw.bounds
+            self.assertEqual(bounds, (693990.0, -2832810.0, 778590.0, -2766600.0))
+
+    def test_bounds_intersection(self):
+        filenames = [l8_224077_20200518_B2, l8_224078_20200518_B2]
+        with gw.open(
+            filenames,
+            band_names=['blue'],
+            mosaic=True,
+            bounds_by='intersection'
+        ) as src:
+            bounds = src.gw.bounds
+            self.assertEqual(bounds, (717330.0, -2812080.0, 754200.0, -2776980.0))
 
     def test_has_time_dim(self):
         with gw.open(

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -9,6 +9,7 @@ from geowombat.data import (
     l8_224077_20200518_B2,
     l8_224077_20200518_B3,
     l8_224078_20200518,
+    l8_224078_20200518_B2,
 )
 
 
@@ -162,6 +163,24 @@ class TestConfig(unittest.TestCase):
                 self.assertTrue(src.equals(tmp_src))
                 self.assertTrue(hasattr(tmp_src, 'TEST_METADATA'))
                 self.assertEqual(tmp_src.TEST_METADATA, 'TEST_VALUE')
+
+    def test_mosaic_save_single_band(self):
+        filenames = [l8_224077_20200518_B2, l8_224078_20200518_B2]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            try:
+                with gw.open(
+                    filenames,
+                    band_names=['blue'],
+                    mosaic=True,
+                    bounds_by='union',
+                    nodata=0,
+                ) as src:
+                    src.gw.save(Path(temp_dir) / 'test.tif', overwrite=True)
+
+            except Exception as e:
+                # If any exception is raised, fail the test with a message
+                self.fail(f"An error occurred during saving: {e}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What is this PR changing?
Following #237:
* Single-band mosaics fail because the `DataArray` reductions remove the band dimension and flip the coordinates.
* This PR replaces previous logic with simplified reductions that: 
  * keep the band dimension
  * ignore 'no data' values during the reductions
  
