### PR TITLE
jgrss/warp cleanup

### DIFF
--- a/src/geowombat/backends/rasterio_.py
+++ b/src/geowombat/backends/rasterio_.py
@@ -790,12 +790,12 @@ def warp(
             vrt_options = {
                 'resampling': getattr(Resampling, resampling),
                 'src_crs': src_crs,
-                'crs': dst_crs,
+                'crs': src_crs,
                 'src_transform': src.transform,
                 'transform': src.transform,
                 'height': dst_height,
                 'width': dst_width,
-                'nodata': nodata,
+                'nodata': None,
                 'warp_mem_limit': warp_mem_limit,
                 'warp_extras': {
                     'multi': True,

--- a/src/geowombat/backends/rasterio_.py
+++ b/src/geowombat/backends/rasterio_.py
@@ -1,6 +1,4 @@
 import logging
-import os
-import shutil
 import threading
 import typing as T
 import warnings
@@ -582,17 +580,17 @@ def get_file_bounds(
 
 
 def warp_images(
-    filenames,
-    bounds_by='union',
-    bounds=None,
-    crs=None,
-    res=None,
-    nodata=0,
-    resampling='nearest',
-    warp_mem_limit=512,
-    num_threads=1,
-    tac=None,
-):
+    filenames: T.Sequence[T.Union[str, Path]],
+    bounds_by: str = 'union',
+    bounds: T.Optional[T.Sequence[float]] = None,
+    crs: T.Optional[T.Union[CRS, dict, int, str]] = None,
+    res: T.Optional[T.Tuple[float, float]] = None,
+    nodata: T.Union[float, int] = 0,
+    resampling: str = 'nearest',
+    warp_mem_limit: int = 512,
+    num_threads: int = 1,
+    tac: T.Optional[T.Tuple[np.ndarray, np.ndarray]] = None,
+) -> T.List[xr.DataArray]:
     """Transforms a list of images to a common grid.
 
     Args:
@@ -629,7 +627,7 @@ def warp_images(
         'tac': tac,
     }
 
-    if bounds:
+    if bounds is not None:
         warp_kwargs['bounds'] = bounds
     else:
 
@@ -667,17 +665,17 @@ def get_ref_image_meta(filename):
 
 
 def warp(
-    filename,
-    resampling='nearest',
-    bounds=None,
-    crs=None,
-    res=None,
-    nodata=0,
-    warp_mem_limit=512,
-    num_threads=1,
-    tap=False,
-    tac=None,
-):
+    filename: T.Union[str, Path],
+    resampling: str = 'nearest',
+    bounds: T.Optional[T.Sequence[float]] = None,
+    crs: T.Optional[T.Union[CRS, dict, int, str]] = None,
+    res: T.Optional[T.Tuple[float, float]] = None,
+    nodata: T.Union[float, int] = 0,
+    warp_mem_limit: int = 512,
+    num_threads: int = 1,
+    tap: bool = False,
+    tac: T.Optional[T.Tuple[np.ndarray, np.ndarray]] = None,
+) -> WarpedVRT:
     """Warps an image to a VRT object.
 
     Args:
@@ -706,7 +704,7 @@ def warp(
     with rio.open(filename) as src:
         src_info = get_file_info(src)
 
-        if res:
+        if res is not None:
             dst_res = check_res(res)
         else:
             dst_res = src_info.src_res
@@ -780,7 +778,7 @@ def warp(
 
         dst_height, dst_width = get_dims_from_bounds(dst_bounds, dst_res)
 
-        # Do not warp if all the key metadata match the reference information
+        # Do all the key metadata match the reference information?
         if (
             (tuple(src_info.src_bounds) == tuple(bounds))
             and (src_info.src_res == dst_res)
@@ -789,8 +787,21 @@ def warp(
             and (src_info.src_height == dst_height)
             and ('.nc' not in filename.lower())
         ):
-
-            output = filename
+            vrt_options = {
+                'resampling': getattr(Resampling, resampling),
+                'src_crs': src_crs,
+                'crs': dst_crs,
+                'src_transform': src.transform,
+                'transform': src.transform,
+                'height': dst_height,
+                'width': dst_width,
+                'nodata': nodata,
+                'warp_mem_limit': warp_mem_limit,
+                'warp_extras': {
+                    'multi': True,
+                    'warp_option': f'NUM_THREADS={num_threads}',
+                },
+            }
 
         else:
             src_transform = Affine(
@@ -810,7 +821,7 @@ def warp(
                 dst_bounds.top,
             )
 
-            if tac:
+            if tac is not None:
                 # Align the cells to target coordinates
                 tap_left = tac[0][np.abs(tac[0] - dst_bounds.left).argmin()]
                 tap_top = tac[1][np.abs(tac[1] - dst_bounds.top).argmin()]
@@ -840,7 +851,8 @@ def warp(
                     'warp_option': f'NUM_THREADS={num_threads}',
                 },
             }
-            output = WarpedVRT(src, **vrt_options)
+
+        output = WarpedVRT(src, **vrt_options)
 
     return output
 

--- a/src/geowombat/backends/xarray_.py
+++ b/src/geowombat/backends/xarray_.py
@@ -55,7 +55,7 @@ def _update_kwarg(ref_obj, ref_kwargs, key):
     return ref_kwargs
 
 
-def _get_raster_coords(filename):
+def _get_raster_coords(filename: T.Union[str, Path]) -> tuple:
     with open_rasterio(filename) as src:
         x = src.x.values - src.res[0] / 2.0
         y = src.y.values + src.res[1] / 2.0
@@ -63,7 +63,11 @@ def _get_raster_coords(filename):
     return x, y
 
 
-def _check_config_globals(filenames, bounds_by, ref_kwargs):
+def _check_config_globals(
+    filenames: T.Union[str, Path, T.Sequence[T.Union[str, Path]]],
+    bounds_by: str,
+    ref_kwargs: dict,
+) -> dict:
     """Checks global configuration parameters.
 
     Args:
@@ -216,16 +220,16 @@ def delayed_to_xarray(
 
 
 def warp_open(
-    filename,
-    band_names=None,
-    resampling='nearest',
-    dtype=None,
-    netcdf_vars=None,
-    nodata=None,
-    return_windows=False,
-    warp_mem_limit=512,
-    num_threads=1,
-    tap=False,
+    filename: T.Union[str, Path],
+    band_names: T.Optional[T.Sequence[T.Union[int, str]]] = None,
+    resampling: str = 'nearest',
+    dtype: T.Optional[str] = None,
+    netcdf_vars: T.Optional[T.Sequence[T.Union[int, str]]] = None,
+    nodata: T.Optional[T.Union[int, float]] = None,
+    return_windows: bool = False,
+    warp_mem_limit: int = 512,
+    num_threads: int = 1,
+    tap: bool = False,
     **kwargs,
 ):
     """Warps and opens a file.
@@ -378,15 +382,15 @@ def warp_open(
 
 
 def mosaic(
-    filenames,
-    overlap='max',
-    bounds_by='reference',
-    resampling='nearest',
-    band_names=None,
-    nodata=None,
-    dtype=None,
-    warp_mem_limit=512,
-    num_threads=1,
+    filenames: T.Sequence[T.Union[str, Path]],
+    overlap: str = 'max',
+    bounds_by: str = 'reference',
+    resampling: str = 'nearest',
+    band_names: T.Optional[T.Sequence[T.Union[int, str]]] = None,
+    nodata: T.Optional[T.Union[float, int]] = None,
+    dtype: T.Optional[str] = None,
+    warp_mem_limit: int = 512,
+    num_threads: int = 1,
     **kwargs,
 ) -> xr.DataArray:
     """Mosaics a list of images.
@@ -512,22 +516,22 @@ def mosaic(
                         **{'sensor': darray.gw.sensor_names[darray.gw.sensor]}
                     )
 
-        darray = darray.assign_attrs(
-            **{'resampling': resampling, 'geometries': geometries}
-        )
+    darray = darray.assign_attrs(
+        **{'resampling': resampling, 'geometries': geometries}
+    )
 
-        if tags:
-            attrs = darray.attrs.copy()
-            attrs.update(tags)
-            darray = darray.assign_attrs(**attrs)
+    if tags:
+        attrs = darray.attrs.copy()
+        attrs.update(tags)
+        darray = darray.assign_attrs(**attrs)
 
-        if dtype is not None:
-            attrs = darray.attrs.copy()
+    if dtype is not None:
+        attrs = darray.attrs.copy()
 
-            return darray.astype(dtype).assign_attrs(**attrs)
+        return darray.astype(dtype).assign_attrs(**attrs)
 
-        else:
-            return darray
+    else:
+        return darray
 
 
 def check_alignment(concat_list: T.Sequence[xr.DataArray]) -> None:

--- a/src/geowombat/backends/xarray_.py
+++ b/src/geowombat/backends/xarray_.py
@@ -549,19 +549,19 @@ def check_alignment(concat_list: T.Sequence[xr.DataArray]) -> None:
 
 
 def concat(
-    filenames,
-    stack_dim='time',
-    bounds_by='reference',
-    resampling='nearest',
-    time_names=None,
-    band_names=None,
-    nodata=None,
-    dtype=None,
-    netcdf_vars=None,
-    overlap='max',
-    warp_mem_limit=512,
-    num_threads=1,
-    tap=False,
+    filenames: T.Sequence[T.Union[str, Path]],
+    stack_dim: str = 'time',
+    bounds_by: str = 'reference',
+    resampling: str = 'nearest',
+    time_names: T.Optional[T.Sequence[T.Any]] = None,
+    band_names: T.Optional[T.Sequence[T.Any]] = None,
+    nodata: T.Optional[T.Union[float, int]] = None,
+    dtype: T.Optional[str] = None,
+    netcdf_vars: T.Optional[T.Sequence[T.Any]] = None,
+    overlap: str = 'max',
+    warp_mem_limit: int = 512,
+    num_threads: int = 1,
+    tap: bool = False,
     **kwargs,
 ):
     """Concatenates a list of images.

--- a/src/geowombat/core/api.py
+++ b/src/geowombat/core/api.py
@@ -1211,7 +1211,12 @@ class series(BaseSeries):
             # check for bigtiff config
             if config["with_config"]:
                 bigtiff = config["bigtiff"].upper()
-                if bigtiff not in ("YES", "NO", "IF_NEEDED", "IF_SAFER"):
+                if bigtiff not in (
+                    "YES",
+                    "NO",
+                    "IF_NEEDED",
+                    "IF_SAFER",
+                ):
                     raise NameError(
                         "The GDAL BIGTIFF must be one of 'YES', 'NO', 'IF_NEEDED', or 'IF_SAFER'. See https://gdal.org/drivers/raster/gtiff.html#creation-issues for more information."
                     )

--- a/src/geowombat/core/api.py
+++ b/src/geowombat/core/api.py
@@ -455,6 +455,8 @@ class open(object):
 
         if isinstance(filename, Path):
             filename = str(filename)
+        elif isinstance(filename, list) and len(filename) == 1:
+            filename = str(filename[0])
 
         self.data = data_
         self.__is_context_manager = False

--- a/src/geowombat/core/geoxarray.py
+++ b/src/geowombat/core/geoxarray.py
@@ -739,6 +739,7 @@ class GeoWombatAccessor(_UpdateConfig, _DataProperties):
         num_workers: T.Optional[int] = 1,
         log_progress: T.Optional[bool] = True,
         tqdm_kwargs: T.Optional[dict] = None,
+        bigtiff: T.Optional[str] = None,
     ) -> None:
         """Saves a DataArray to raster using rasterio/dask.
 
@@ -764,6 +765,7 @@ class GeoWombatAccessor(_UpdateConfig, _DataProperties):
                 Default is 1.
             log_progress (Optional[bool]): Whether to log the progress bar during writing. Default is True.
             tqdm_kwargs (Optional[dict]): Keyword arguments to pass to ``tqdm``.
+            bigtiff (Optional[str]): A GDAL BIGTIFF flag. E.g., 'IF_SAFER' or 'YES'.
 
         Returns:
             ``None``, writes to ``filename``
@@ -796,6 +798,7 @@ class GeoWombatAccessor(_UpdateConfig, _DataProperties):
             num_workers=num_workers,
             log_progress=log_progress,
             tqdm_kwargs=tqdm_kwargs,
+            bigtiff=bigtiff,
         )
 
     def to_raster(

--- a/src/geowombat/core/geoxarray.py
+++ b/src/geowombat/core/geoxarray.py
@@ -765,7 +765,7 @@ class GeoWombatAccessor(_UpdateConfig, _DataProperties):
                 Default is 1.
             log_progress (Optional[bool]): Whether to log the progress bar during writing. Default is True.
             tqdm_kwargs (Optional[dict]): Keyword arguments to pass to ``tqdm``.
-            bigtiff (Optional[str]): A GDAL BIGTIFF flag. E.g., 'IF_SAFER' or 'YES'.
+            bigtiff (Optional[str]): A GDAL BIGTIFF flag. Choices are ["YES", "NO", "IF_NEEDED", "IF_SAFER"].
 
         Returns:
             ``None``, writes to ``filename``

--- a/src/geowombat/core/io.py
+++ b/src/geowombat/core/io.py
@@ -796,9 +796,6 @@ def save(
                 "IF_NEEDED",
                 "IF_SAFER",
             ):
-                import ipdb
-
-                ipdb.set_trace()
                 raise NameError(
                     "The GDAL BIGTIFF must be one of 'YES', 'NO', 'IF_NEEDED', or 'IF_SAFER'. See https://gdal.org/drivers/raster/gtiff.html#creation-issues for more information."
                 )

--- a/src/geowombat/core/io.py
+++ b/src/geowombat/core/io.py
@@ -693,6 +693,7 @@ def save(
     num_workers: T.Optional[int] = 1,
     log_progress: T.Optional[bool] = True,
     tqdm_kwargs: T.Optional[dict] = None,
+    bigtiff: T.Optional[str] = None,
 ):
     """Saves a DataArray to raster using rasterio/dask.
 
@@ -793,7 +794,7 @@ def save(
         compress=compress,
         tiled=True if max(blockxsize, blockysize) >= 16 else False,
         sharing=False,
-        bigtiff="IF_SAFER",
+        bigtiff=bigtiff,
     )
 
     if data.gw.bigtiff:

--- a/src/geowombat/core/io.py
+++ b/src/geowombat/core/io.py
@@ -546,9 +546,11 @@ def to_vrt(
             xRes=data.gw.cellx,
             yRes=data.gw.celly,
             separate=separate,
-            outputSRS=data.crs,
+            outputSRS=data.gw.crs_to_pyproj.to_wkt(),
         )
-        ds = gdal.BuildVRT(filename, data.gw.filenames, options=vrt_options)
+        ds = gdal.BuildVRT(
+            str(filename), data.gw.filenames, options=vrt_options
+        )
         ds = None
 
 

--- a/src/geowombat/core/io.py
+++ b/src/geowombat/core/io.py
@@ -762,6 +762,7 @@ def save(
                 raise AttributeError(
                     "The DataArray does not have any 'no data' attributes."
                 )
+
     dtype = data.dtype.name if isinstance(data.dtype, np.dtype) else data.dtype
     if isinstance(nodata, float):
         if dtype != "float32":
@@ -998,11 +999,9 @@ def to_raster(
     else:
         compress = False
 
-    if "nodata" not in kwargs:
-        if isinstance(data.gw.nodata, int) or isinstance(
-            data.gw.nodata, float
-        ):
-            kwargs["nodata"] = data.gw.nodata
+    if kwargs.get("nodata") is None:
+        if isinstance(data.gw.nodataval, (float, int)):
+            kwargs["nodata"] = data.gw.nodataval
 
     if "blockxsize" not in kwargs:
         kwargs["blockxsize"] = data.gw.col_chunks
@@ -1044,6 +1043,7 @@ def to_raster(
             kwargs["crs"] = pyproj.CRS.from_epsg(int(crs))
         except ValueError:
             kwargs["crs"] = pyproj.CRS.from_user_input(crs)
+
     kwargs["crs"] = kwargs["crs"].to_wkt()
 
     root = None

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -15,45 +15,45 @@ from geowombat.data import (
 
 class TestConfig(unittest.TestCase):
     def test_to_netcdf(self):
-        bands = ['blue', 'green', 'red']
+        bands = ["blue", "green", "red"]
         with tempfile.TemporaryDirectory() as tmp:
-            out_path = Path(tmp) / 'test.nc'
+            out_path = Path(tmp) / "test.nc"
             with gw.open(l8_224078_20200518, band_names=bands) as src:
                 (
                     src.fillna(32768)
                     .gw.assign_nodata_attrs(32768)
-                    .astype('uint16')
+                    .astype("uint16")
                     .gw.to_netcdf(filename=out_path, overwrite=True)
                 )
 
     def test_to_raster(self):
         with tempfile.TemporaryDirectory() as tmp:
-            out_path = Path(tmp) / 'test.tif'
+            out_path = Path(tmp) / "test.tif"
             with gw.open(l8_224078_20200518) as src:
                 (
                     src.fillna(32768)
                     .gw.assign_nodata_attrs(32768)
-                    .astype('uint16')
+                    .astype("uint16")
                     .gw.to_raster(
                         filename=out_path,
                         overwrite=True,
-                        tags={'TEST_METADATA': 'TEST_VALUE'},
-                        compress='lzw',
+                        tags={"TEST_METADATA": "TEST_VALUE"},
+                        compress="lzw",
                         num_workers=2,
                     )
                 )
                 with gw.open(out_path) as tmp_src:
                     self.assertTrue(src.equals(tmp_src))
-                    self.assertTrue(hasattr(tmp_src, 'TEST_METADATA'))
-                    self.assertEqual(tmp_src.TEST_METADATA, 'TEST_VALUE')
+                    self.assertTrue(hasattr(tmp_src, "TEST_METADATA"))
+                    self.assertEqual(tmp_src.TEST_METADATA, "TEST_VALUE")
 
     def test_to_raster_multi(self):
         with tempfile.TemporaryDirectory() as tmp:
-            out_path = Path(tmp) / 'test.tif'
+            out_path = Path(tmp) / "test.tif"
             with gw.open(
                 [l8_224077_20200518_B2, l8_224077_20200518_B3],
-                stack_dim='band',
-                band_names=['B2', 'B3'],
+                stack_dim="band",
+                band_names=["B2", "B3"],
             ) as src:
                 # Xarray drops attributes
                 attrs = src.attrs.copy()
@@ -64,7 +64,7 @@ class TestConfig(unittest.TestCase):
                     out_path, overwrite=True
                 )
                 self.assertTrue(out_path.is_file())
-                with gw.open(out_path, band_names=['B2', 'B3']) as tmp_src:
+                with gw.open(out_path, band_names=["B2", "B3"]) as tmp_src:
                     self.assertTrue(src.equals(tmp_src))
 
     # def test_to_raster_bigtiff(self):
@@ -96,63 +96,82 @@ class TestConfig(unittest.TestCase):
     #             except FileExistsError:
     #                 self.assertTrue(False)
 
+    def test_bigtiff(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out_path = Path(tmp) / "test.tif"
+            with gw.config.update({"bigtiff": True}):
+                with gw.open(l8_224078_20200518) as src:
+                    (
+                        src.fillna(32768)
+                        .gw.assign_nodata_attrs(32768)
+                        .astype("uint16")
+                        .gw.save(
+                            filename=out_path,
+                            overwrite=True,
+                            compress="lzw",
+                            num_workers=2,
+                        )
+                    )
+                    with gw.open(out_path) as tmp_src:
+                        self.assertTrue(src.equals(tmp_src))
+
     def test_save(self):
         with tempfile.TemporaryDirectory() as tmp:
-            out_path = Path(tmp) / 'test.tif'
+            out_path = Path(tmp) / "test.tif"
             with gw.open(l8_224078_20200518) as src:
                 (
                     src.fillna(32768)
                     .gw.assign_nodata_attrs(32768)
-                    .astype('uint16')
+                    .astype("uint16")
                     .gw.save(
                         filename=out_path,
                         overwrite=True,
-                        tags={'TEST_METADATA': 'TEST_VALUE'},
-                        compress='lzw',
+                        tags={"TEST_METADATA": "TEST_VALUE"},
+                        compress="lzw",
                         num_workers=2,
                     )
                 )
                 with gw.open(out_path) as tmp_src:
                     self.assertTrue(src.equals(tmp_src))
-                    self.assertTrue(hasattr(tmp_src, 'TEST_METADATA'))
-                    self.assertEqual(tmp_src.TEST_METADATA, 'TEST_VALUE')
+                    self.assertTrue(hasattr(tmp_src, "TEST_METADATA"))
+                    self.assertEqual(tmp_src.TEST_METADATA, "TEST_VALUE")
 
     def test_save_small(self):
         with tempfile.TemporaryDirectory() as tmp:
-            out_path = Path(tmp) / 'test.tif'
+            out_path = Path(tmp) / "test.tif"
             with gw.open(l8_224078_20200518) as src:
                 data = src[:, :1, :2]
                 try:
                     (
                         data.fillna(32768)
                         .gw.assign_nodata_attrs(32768)
-                        .astype('uint16')
+                        .astype("uint16")
                         .gw.save(
                             filename=out_path,
                             overwrite=True,
-                            tags={'TEST_METADATA': 'TEST_VALUE'},
-                            compress='none',
+                            tags={"TEST_METADATA": "TEST_VALUE"},
+                            compress="none",
                             num_workers=1,
                         )
                     )
                 except ValueError:
-                    self.fail('The small array write test failed.')
+                    self.fail("The small array write test failed.")
 
     def test_delayed_save(self):
         with tempfile.TemporaryDirectory() as tmp:
-            out_path = Path(tmp) / 'test.tif'
+            out_path = Path(tmp) / "test.tif"
             with gw.open(l8_224078_20200518) as src:
                 src = (
                     src.fillna(32768)
                     .gw.assign_nodata_attrs(32768)
-                    .astype('uint16')
+                    .astype("uint16")
                 )
                 tasks = [
                     gw.save(
                         src,
                         filename=out_path,
-                        tags={'TEST_METADATA': 'TEST_VALUE'},
-                        compress='lzw',
+                        tags={"TEST_METADATA": "TEST_VALUE"},
+                        compress="lzw",
                         num_workers=2,
                         compute=False,
                         overwrite=True,
@@ -161,8 +180,8 @@ class TestConfig(unittest.TestCase):
             dask.compute(tasks, num_workers=2)
             with gw.open(out_path) as tmp_src:
                 self.assertTrue(src.equals(tmp_src))
-                self.assertTrue(hasattr(tmp_src, 'TEST_METADATA'))
-                self.assertEqual(tmp_src.TEST_METADATA, 'TEST_VALUE')
+                self.assertTrue(hasattr(tmp_src, "TEST_METADATA"))
+                self.assertEqual(tmp_src.TEST_METADATA, "TEST_VALUE")
 
     def test_mosaic_save_single_band(self):
         filenames = [l8_224077_20200518_B2, l8_224078_20200518_B2]
@@ -171,17 +190,17 @@ class TestConfig(unittest.TestCase):
             try:
                 with gw.open(
                     filenames,
-                    band_names=['blue'],
+                    band_names=["blue"],
                     mosaic=True,
-                    bounds_by='union',
+                    bounds_by="union",
                     nodata=0,
                 ) as src:
-                    src.gw.save(Path(temp_dir) / 'test.tif', overwrite=True)
+                    src.gw.save(Path(temp_dir) / "test.tif", overwrite=True)
 
             except Exception as e:
                 # If any exception is raised, fail the test with a message
                 self.fail(f"An error occurred during saving: {e}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 
 import dask
+import rasterio as rio
 
 import geowombat as gw
 from geowombat.data import (
@@ -12,40 +13,52 @@ from geowombat.data import (
     l8_224078_20200518_B2,
 )
 
+NODATA = 32768
 
-class TestConfig(unittest.TestCase):
+
+class TestWrite(unittest.TestCase):
     def test_to_netcdf(self):
         bands = ["blue", "green", "red"]
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "test.nc"
             with gw.open(l8_224078_20200518, band_names=bands) as src:
-                (
-                    src.fillna(32768)
-                    .gw.assign_nodata_attrs(32768)
-                    .astype("uint16")
-                    .gw.to_netcdf(filename=out_path, overwrite=True)
-                )
+                try:
+                    (
+                        src.gw.set_nodata(0, 32768)
+                        .astype("uint16")
+                        .gw.to_netcdf(filename=out_path, overwrite=True)
+                    )
+                except Exception as e:
+                    # If any exception is raised, fail the test with a message
+                    self.fail(f"An error occurred during saving: {e}")
 
     def test_to_raster(self):
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "test.tif"
+
             with gw.open(l8_224078_20200518) as src:
-                (
-                    src.fillna(32768)
-                    .gw.assign_nodata_attrs(32768)
-                    .astype("uint16")
-                    .gw.to_raster(
-                        filename=out_path,
-                        overwrite=True,
-                        tags={"TEST_METADATA": "TEST_VALUE"},
-                        compress="lzw",
-                        num_workers=2,
-                    )
+                data = src.gw.set_nodata(0, 32768).astype("uint16")
+                data.gw.to_raster(
+                    filename=out_path,
+                    overwrite=True,
+                    tags={"TEST_METADATA": "TEST_VALUE"},
+                    compress="lzw",
+                    num_workers=2,
                 )
+
                 with gw.open(out_path) as tmp_src:
-                    self.assertTrue(src.equals(tmp_src))
+                    # Compare array values
+                    self.assertTrue(data.equals(tmp_src))
+                    # Compare attributes
+                    self.assertTrue(
+                        data.gw.nodataval == tmp_src.gw.nodataval == NODATA
+                    )
+                    self.assertEqual(data.gw.dtype, tmp_src.dtype)
                     self.assertTrue(hasattr(tmp_src, "TEST_METADATA"))
                     self.assertEqual(tmp_src.TEST_METADATA, "TEST_VALUE")
+
+            with rio.open(out_path) as rio_src:
+                self.assertTrue(rio_src.nodata == NODATA)
 
     def test_to_raster_multi(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -56,74 +69,56 @@ class TestConfig(unittest.TestCase):
                 band_names=["B2", "B3"],
             ) as src:
                 # Xarray drops attributes
-                attrs = src.attrs.copy()
+                data = src.gw.set_nodata(0, 32768).astype("uint16")
+                attrs = data.attrs.copy()
                 # Apply operations on the DataArray
-                src = src * 10.0
+                data = (data * 10.0).assign_attrs(**attrs)
                 # Write the data to a GeoTiff
-                src.assign_attrs(**attrs).gw.to_raster(
-                    out_path, overwrite=True
-                )
+                data.gw.to_raster(out_path, overwrite=True)
                 self.assertTrue(out_path.is_file())
                 with gw.open(out_path, band_names=["B2", "B3"]) as tmp_src:
-                    self.assertTrue(src.equals(tmp_src))
-
-    # def test_to_raster_bigtiff(self):
-    #     """This test was added following Issue #242
-    #     """
-    #     with tempfile.TemporaryDirectory() as tmp:
-    #         out_path = Path(tmp) / 'test.tif'
-    #         with gw.open(l8_224077_20200518_B2) as src:
-    #             src.gw.to_raster(
-    #                 out_path,
-    #                 overwrite=True,
-    #                 bigtiff=True,
-    #                 nodata=0,
-    #                 n_jobs=2,
-    #                 verbose=1,
-    #                 compress='lzw'
-    #             )
-    #             try:
-    #                 src.gw.to_raster(
-    #                     out_path,
-    #                     overwrite=True,
-    #                     bigtiff=True,
-    #                     nodata=0,
-    #                     n_jobs=2,
-    #                     verbose=1,
-    #                     compress='lzw'
-    #                 )
-    #             # NOTE: this likely won't catch on Windows
-    #             except FileExistsError:
-    #                 self.assertTrue(False)
+                    # Compare array values
+                    self.assertTrue(data.equals(tmp_src))
+                    # Compare attributes
+                    self.assertTrue(
+                        data.gw.nodataval == tmp_src.gw.nodataval == NODATA
+                    )
+                    self.assertEqual(data.gw.dtype, tmp_src.dtype)
 
     def test_bigtiff(self):
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "test.tif"
             with gw.config.update({"bigtiff": True}):
                 with gw.open(l8_224078_20200518) as src:
+                    data = src.gw.set_nodata(0, NODATA, dtype="uint16")
                     (
-                        src.fillna(32768)
-                        .gw.assign_nodata_attrs(32768)
-                        .astype("uint16")
-                        .gw.save(
+                        data.gw.save(
                             filename=out_path,
                             overwrite=True,
                             compress="lzw",
                             num_workers=2,
                         )
                     )
+
                     with gw.open(out_path) as tmp_src:
-                        self.assertTrue(src.equals(tmp_src))
+                        # Compare array values
+                        self.assertTrue(data.equals(tmp_src))
+                        # Compare attributes
+                        self.assertTrue(
+                            data.gw.nodataval == tmp_src.gw.nodataval == NODATA
+                        )
+                        self.assertEqual(data.gw.dtype, tmp_src.dtype)
+
+            with rio.open(out_path) as rio_src:
+                self.assertTrue(rio_src.nodata == NODATA)
 
     def test_save(self):
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "test.tif"
             with gw.open(l8_224078_20200518) as src:
+                data = src.gw.set_nodata(0, NODATA, dtype="uint16")
                 (
-                    src.fillna(32768)
-                    .gw.assign_nodata_attrs(32768)
-                    .astype("uint16")
-                    .gw.save(
+                    data.gw.save(
                         filename=out_path,
                         overwrite=True,
                         tags={"TEST_METADATA": "TEST_VALUE"},
@@ -132,27 +127,33 @@ class TestConfig(unittest.TestCase):
                     )
                 )
                 with gw.open(out_path) as tmp_src:
-                    self.assertTrue(src.equals(tmp_src))
+                    # Compare array values
+                    self.assertTrue(data.equals(tmp_src))
+                    # Compare attributes
+                    self.assertTrue(
+                        data.gw.nodataval == tmp_src.gw.nodataval == NODATA
+                    )
+                    self.assertEqual(data.gw.dtype, tmp_src.dtype)
                     self.assertTrue(hasattr(tmp_src, "TEST_METADATA"))
                     self.assertEqual(tmp_src.TEST_METADATA, "TEST_VALUE")
+
+            with rio.open(out_path) as rio_src:
+                self.assertTrue(rio_src.nodata == NODATA)
 
     def test_save_small(self):
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "test.tif"
             with gw.open(l8_224078_20200518) as src:
-                data = src[:, :1, :2]
+                data = src.gw.set_nodata(0, NODATA, dtype="uint16")
+                data = data[:, :1, :2]
+
                 try:
-                    (
-                        data.fillna(32768)
-                        .gw.assign_nodata_attrs(32768)
-                        .astype("uint16")
-                        .gw.save(
-                            filename=out_path,
-                            overwrite=True,
-                            tags={"TEST_METADATA": "TEST_VALUE"},
-                            compress="none",
-                            num_workers=1,
-                        )
+                    data.gw.save(
+                        filename=out_path,
+                        overwrite=True,
+                        tags={"TEST_METADATA": "TEST_VALUE"},
+                        compress="none",
+                        num_workers=1,
                     )
                 except ValueError:
                     self.fail("The small array write test failed.")
@@ -161,14 +162,10 @@ class TestConfig(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             out_path = Path(tmp) / "test.tif"
             with gw.open(l8_224078_20200518) as src:
-                src = (
-                    src.fillna(32768)
-                    .gw.assign_nodata_attrs(32768)
-                    .astype("uint16")
-                )
+                data = src.gw.set_nodata(0, NODATA, dtype="uint16")
                 tasks = [
                     gw.save(
-                        src,
+                        data,
                         filename=out_path,
                         tags={"TEST_METADATA": "TEST_VALUE"},
                         compress="lzw",
@@ -179,9 +176,18 @@ class TestConfig(unittest.TestCase):
                 ]
             dask.compute(tasks, num_workers=2)
             with gw.open(out_path) as tmp_src:
-                self.assertTrue(src.equals(tmp_src))
+                # Compare array values
+                self.assertTrue(data.equals(tmp_src))
+                # Compare attributes
+                self.assertTrue(
+                    data.gw.nodataval == tmp_src.gw.nodataval == NODATA
+                )
+                self.assertEqual(data.gw.dtype, tmp_src.dtype)
                 self.assertTrue(hasattr(tmp_src, "TEST_METADATA"))
                 self.assertEqual(tmp_src.TEST_METADATA, "TEST_VALUE")
+
+            with rio.open(out_path) as rio_src:
+                self.assertTrue(rio_src.nodata == NODATA)
 
     def test_mosaic_save_single_band(self):
         filenames = [l8_224077_20200518_B2, l8_224078_20200518_B2]


### PR DESCRIPTION
## What is this PR changing?
* Simplifies the `mosaic()` method and ensures support for multi-band mosaics
* Fixes bug in `to_raster()`, where `nodata` values were not being written to file
* Adds `bigtiff` keyword argument to `save()` method
* Updates write tests